### PR TITLE
Rename Typed-prefixed selector and extractor APIs

### DIFF
--- a/crates/solverforge-core/WIREFRAME.md
+++ b/crates/solverforge-core/WIREFRAME.md
@@ -39,7 +39,7 @@ src/
 ├── domain/
 │   ├── mod.rs                             — Module declarations and re-exports for domain types
 │   ├── traits.rs                          — PlanningSolution, PlanningEntity, ProblemFact, PlanningId, ListVariableSolution
-│   ├── entity_ref.rs                      — EntityRef, EntityExtractor trait, TypedEntityExtractor
+│   ├── entity_ref.rs                      — EntityRef, EntityExtractor trait, EntityCollectionExtractor
 │   ├── variable.rs                        — VariableType, ShadowVariableKind, ValueRangeType, ChainedVariableInfo
 │   ├── value_range.rs                     — ValueRangeProvider trait, FieldValueRangeProvider, ComputedValueRangeProvider, StaticValueRange, IntegerRange
 │   ├── descriptor/
@@ -65,7 +65,7 @@ src/
 │   │   └── tests.rs                       — Supply tests (inverse, anchor, list_state)
 │   └── tests/
 │       ├── mod.rs                         — Test module declarations
-│       ├── entity_ref_tests.rs            — TypedEntityExtractor tests
+│       ├── entity_ref_tests.rs            — EntityCollectionExtractor tests
 │       ├── value_range_tests.rs           — ValueRangeProvider tests
 │       └── variable_tests.rs             — VariableType, ShadowVariableKind, ChainedVariableInfo tests
 ```
@@ -318,10 +318,10 @@ pub struct EntityRef {
 
 Derives: `Debug, Clone`
 
-#### `TypedEntityExtractor<S, E>`
+#### `EntityCollectionExtractor<S, E>`
 
 ```rust
-pub struct TypedEntityExtractor<S, E> {
+pub struct EntityCollectionExtractor<S, E> {
     type_name: &'static str,                       // private
     collection_field: &'static str,                 // private
     get_collection: fn(&S) -> &Vec<E>,              // private
@@ -606,7 +606,7 @@ All three supply types (InverseSupply, AnchorSupply, ListStateSupply) follow str
 
 ### EntityExtractor as Intentional dyn Boundary
 
-`EntityExtractor` is a `dyn` trait object — this is an **intentional type-erasure boundary**. Descriptors need to work with entities of unknown concrete type at runtime. The `TypedEntityExtractor<S, E>` provides the concrete implementation that downcasts via `Any`. `Box<dyn EntityExtractor>` appears in `EntityDescriptor` and `ProblemFactDescriptor`.
+`EntityExtractor` is a `dyn` trait object — this is an **intentional type-erasure boundary**. Descriptors need to work with entities of unknown concrete type at runtime. The `EntityCollectionExtractor<S, E>` provides the concrete implementation that downcasts via `Any`. `Box<dyn EntityExtractor>` appears in `EntityDescriptor` and `ProblemFactDescriptor`.
 
 ### PhantomData Pattern
 

--- a/crates/solverforge-core/src/domain/descriptor/tests/entity_descriptor.rs
+++ b/crates/solverforge-core/src/domain/descriptor/tests/entity_descriptor.rs
@@ -3,7 +3,7 @@ use std::any::TypeId;
 
 #[test]
 fn test_with_extractor() {
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "TestEntity",
         "entities",
         get_entities,

--- a/crates/solverforge-core/src/domain/descriptor/tests/mod.rs
+++ b/crates/solverforge-core/src/domain/descriptor/tests/mod.rs
@@ -5,7 +5,7 @@ mod solution_descriptor;
 mod variable_descriptor;
 
 use crate::domain::descriptor::*;
-use crate::domain::TypedEntityExtractor;
+use crate::domain::EntityCollectionExtractor;
 use std::any::Any;
 
 // Shared test helpers used across descriptor test modules.
@@ -30,7 +30,7 @@ pub(super) fn get_entities_mut(s: &mut TestSolution) -> &mut Vec<TestEntity> {
 }
 
 pub(super) fn create_test_entity_descriptor() -> EntityDescriptor {
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "TestEntity",
         "entities",
         get_entities,

--- a/crates/solverforge-core/src/domain/entity_ref.rs
+++ b/crates/solverforge-core/src/domain/entity_ref.rs
@@ -74,7 +74,7 @@ impl Clone for Box<dyn EntityExtractor> {
 /// # Type Parameters
 /// * `S` - The solution type
 /// * `E` - The entity type
-pub struct TypedEntityExtractor<S, E> {
+pub struct EntityCollectionExtractor<S, E> {
     // Name of the entity type.
     type_name: &'static str,
     // Name of the collection field in the solution.
@@ -85,7 +85,7 @@ pub struct TypedEntityExtractor<S, E> {
     get_collection_mut: fn(&mut S) -> &mut Vec<E>,
 }
 
-impl<S, E> TypedEntityExtractor<S, E>
+impl<S, E> EntityCollectionExtractor<S, E>
 where
     S: 'static,
     E: 'static,
@@ -105,7 +105,7 @@ where
     }
 }
 
-impl<S, E> EntityExtractor for TypedEntityExtractor<S, E>
+impl<S, E> EntityExtractor for EntityCollectionExtractor<S, E>
 where
     S: Send + Sync + 'static,
     E: Clone + Send + Sync + 'static,
@@ -162,9 +162,9 @@ where
     }
 }
 
-impl<S, E> Debug for TypedEntityExtractor<S, E> {
+impl<S, E> Debug for EntityCollectionExtractor<S, E> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TypedEntityExtractor")
+        f.debug_struct("EntityCollectionExtractor")
             .field("type_name", &self.type_name)
             .field("collection_field", &self.collection_field)
             .finish()

--- a/crates/solverforge-core/src/domain/mod.rs
+++ b/crates/solverforge-core/src/domain/mod.rs
@@ -21,7 +21,7 @@ mod tests;
 pub use descriptor::{
     EntityDescriptor, ProblemFactDescriptor, SolutionDescriptor, VariableDescriptor,
 };
-pub use entity_ref::{EntityExtractor, EntityRef, TypedEntityExtractor};
+pub use entity_ref::{EntityCollectionExtractor, EntityExtractor, EntityRef};
 pub use listener::{
     ListVariableListener, ListVariableNotification, VariableListener, VariableNotification,
 };

--- a/crates/solverforge-core/src/domain/tests/entity_ref_tests.rs
+++ b/crates/solverforge-core/src/domain/tests/entity_ref_tests.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use crate::domain::{EntityExtractor, TypedEntityExtractor};
+use crate::domain::{EntityCollectionExtractor, EntityExtractor};
 
 #[derive(Clone, Debug)]
 struct TestEntity {
@@ -24,7 +24,7 @@ fn get_entities_mut(s: &mut TestSolution) -> &mut Vec<TestEntity> {
 #[test]
 fn test_typed_entity_extractor_count() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     let solution = TestSolution {
         entities: vec![
@@ -47,7 +47,7 @@ fn test_typed_entity_extractor_count() {
 #[test]
 fn test_typed_entity_extractor_get() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     let solution = TestSolution {
         entities: vec![
@@ -76,7 +76,7 @@ fn test_typed_entity_extractor_get() {
 #[test]
 fn test_typed_entity_extractor_get_mut() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     let mut solution = TestSolution {
         entities: vec![TestEntity {
@@ -96,7 +96,7 @@ fn test_typed_entity_extractor_get_mut() {
 #[test]
 fn test_typed_entity_extractor_entity_refs() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     let solution = TestSolution {
         entities: vec![
@@ -122,7 +122,7 @@ fn test_typed_entity_extractor_entity_refs() {
 #[test]
 fn test_extractor_wrong_solution_type() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     let wrong_solution = "not a solution";
     let count = extractor.count(&wrong_solution as &dyn Any);
@@ -131,7 +131,7 @@ fn test_extractor_wrong_solution_type() {
 
 #[test]
 fn test_extractor_clone() {
-    let extractor: Box<dyn EntityExtractor> = Box::new(TypedEntityExtractor::new(
+    let extractor: Box<dyn EntityExtractor> = Box::new(EntityCollectionExtractor::new(
         "TestEntity",
         "entities",
         get_entities,
@@ -153,7 +153,7 @@ fn test_extractor_clone() {
 #[test]
 fn test_clone_entity_boxed() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     let solution = TestSolution {
         entities: vec![
@@ -192,7 +192,7 @@ fn test_clone_entity_boxed() {
 #[test]
 fn test_entity_type_id() {
     let extractor =
-        TypedEntityExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
+        EntityCollectionExtractor::new("TestEntity", "entities", get_entities, get_entities_mut);
 
     assert_eq!(
         extractor.entity_type_id(),

--- a/crates/solverforge-macros/WIREFRAME.md
+++ b/crates/solverforge-macros/WIREFRAME.md
@@ -178,7 +178,7 @@ struct BasicVariableConfig {
 All generated code references types via `::solverforge::__internal::*` paths, meaning the generated code depends on the `solverforge` facade crate re-exporting core types under `__internal`. Key referenced types:
 - `PlanningEntity`, `PlanningSolution`, `PlanningId`, `ProblemFact`
 - `EntityDescriptor`, `SolutionDescriptor`, `ProblemFactDescriptor`, `VariableDescriptor`
-- `TypedEntityExtractor`
+- `EntityCollectionExtractor`
 - `ShadowVariableKind`, `ShadowVariableSupport`, `SolvableSolution`
 - `ScoreDirector`, `Director`
 

--- a/crates/solverforge-macros/src/planning_solution.rs
+++ b/crates/solverforge-macros/src/planning_solution.rs
@@ -185,7 +185,7 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
                     stringify!(#element_type),
                     ::std::any::TypeId::of::<#element_type>(),
                     #field_name_str,
-                ).with_extractor(Box::new(::solverforge::__internal::TypedEntityExtractor::new(
+                ).with_extractor(Box::new(::solverforge::__internal::EntityCollectionExtractor::new(
                     stringify!(#element_type),
                     #field_name_str,
                     |s: &#name| &s.#field_name,
@@ -207,7 +207,7 @@ pub fn expand_derive(input: DeriveInput) -> Result<TokenStream, Error> {
                     stringify!(#element_type),
                     ::std::any::TypeId::of::<#element_type>(),
                     #field_name_str,
-                ).with_extractor(Box::new(::solverforge::__internal::TypedEntityExtractor::new(
+                ).with_extractor(Box::new(::solverforge::__internal::EntityCollectionExtractor::new(
                     stringify!(#element_type),
                     #field_name_str,
                     |s: &#name| &s.#field_name,

--- a/crates/solverforge-scoring/WIREFRAME.md
+++ b/crates/solverforge-scoring/WIREFRAME.md
@@ -485,4 +485,4 @@ All types use `PhantomData<(fn() -> S, fn() -> A, ...)>` to avoid inheriting bou
 
 ## Cross-Crate Dependencies
 
-- **From `solverforge-core`:** `Score`, `PlanningSolution`, `ConstraintRef`, `ImpactType`, `SolutionDescriptor`, `EntityDescriptor`, `ProblemFactDescriptor`, `VariableDescriptor`, `TypedEntityExtractor`
+- **From `solverforge-core`:** `Score`, `PlanningSolution`, `ConstraintRef`, `ImpactType`, `SolutionDescriptor`, `EntityDescriptor`, `ProblemFactDescriptor`, `VariableDescriptor`, `EntityCollectionExtractor`

--- a/crates/solverforge-solver/WIREFRAME.md
+++ b/crates/solverforge-solver/WIREFRAME.md
@@ -83,9 +83,9 @@ src/
 │   └── selector/
 │       ├── mod.rs                       — Re-exports
 │       ├── entity.rs                    — EntitySelector trait, FromSolutionEntitySelector, AllEntitiesSelector
-│       ├── typed_value.rs              — TypedValueSelector trait, StaticTypedValueSelector, FromSolutionTypedValueSelector
-│       ├── typed_move_selector.rs      — MoveSelector trait, ChangeMoveSelector, SwapMoveSelector, EitherChange/SwapMoveSelector, ListMove* wrappers
-│       ├── typed_move_selector_tests.rs — Tests
+│       ├── value_selector.rs              — ValueSelector trait, StaticValueSelector, FromSolutionValueSelector
+│       ├── move_selector.rs      — MoveSelector trait, ChangeMoveSelector, SwapMoveSelector, EitherChange/SwapMoveSelector, ListMove* wrappers
+│       ├── move_selector_tests.rs — Tests
 │       ├── list_change.rs              — ListChangeMoveSelector<S, V, ES>
 │       ├── list_swap.rs                — ListSwapMoveSelector<S, V, ES>, ListMoveListSwapSelector
 │       ├── list_reverse.rs             — ListReverseMoveSelector<S, V, ES>, ListMoveListReverseSelector
@@ -129,7 +129,7 @@ src/
 │           ├── mimic.rs
 │           ├── nearby.rs
 │           ├── pillar.rs
-│           └── typed_move_selector.rs
+│           └── move_selector.rs
 │
 ├── phase/
 │   ├── mod.rs                           — Phase<S, D> trait, tuple impls
@@ -273,7 +273,7 @@ Requires: `Send + Debug`.
 | `size` | `fn<D: Director<S>>(&self, score_director: &D) -> usize` |
 | `is_never_ending` | `fn(&self) -> bool` |
 
-### `MoveSelector<S: PlanningSolution, M: Move<S>>` — `typed_move_selector.rs`
+### `MoveSelector<S: PlanningSolution, M: Move<S>>` — `move_selector.rs`
 
 | Method | Signature |
 |--------|-----------|
@@ -281,7 +281,7 @@ Requires: `Send + Debug`.
 | `size` | `fn<D: Director<S>>(&self, score_director: &D) -> usize` |
 | `is_never_ending` | `fn(&self) -> bool` |
 
-### `TypedValueSelector<S: PlanningSolution, V>` — `typed_value.rs`
+### `ValueSelector<S: PlanningSolution, V>` — `value_selector.rs`
 
 | Method | Signature |
 |--------|-----------|
@@ -461,8 +461,8 @@ All moves are generic over `S` (solution) and `V` (value). All use typed `fn` po
 
 | Selector | Note |
 |----------|------|
-| `StaticTypedValueSelector<S, V>` | Fixed value list |
-| `FromSolutionTypedValueSelector<S, V>` | Extracts values from solution via `fn(&S) -> Vec<V>` |
+| `StaticValueSelector<S, V>` | Fixed value list |
+| `FromSolutionValueSelector<S, V>` | Extracts values from solution via `fn(&S) -> Vec<V>` |
 | `RangeValueSelector<S>` | Generates 0..count_fn(solution) |
 
 ### Move Selectors

--- a/crates/solverforge-solver/src/basic.rs
+++ b/crates/solverforge-solver/src/basic.rs
@@ -28,7 +28,7 @@ use crate::heuristic::selector::decorator::UnionMoveSelector;
 use crate::heuristic::selector::decorator::VecUnionSelector;
 use crate::heuristic::selector::{
     EitherChangeMoveSelector, EitherSwapMoveSelector, FromSolutionEntitySelector,
-    StaticTypedValueSelector,
+    StaticValueSelector,
 };
 use crate::phase::construction::{BestFitForager, ConstructionHeuristicPhase, QueuedEntityPlacer};
 use crate::phase::localsearch::{LocalSearchPhase, SimulatedAnnealingAcceptor};
@@ -56,7 +56,7 @@ type DefaultLocalSearch<S> = LocalSearchPhase<
             S,
             usize,
             FromSolutionEntitySelector,
-            StaticTypedValueSelector<S, usize>,
+            StaticValueSelector<S, usize>,
         >,
         EitherSwapMoveSelector<S, usize, FromSolutionEntitySelector, FromSolutionEntitySelector>,
     >,
@@ -120,7 +120,7 @@ where
         let n_values = (self.value_count)(director.working_solution());
         let values: Vec<usize> = (0..n_values).collect();
         let entity_selector = FromSolutionEntitySelector::new(0);
-        let value_selector = StaticTypedValueSelector::new(values.clone());
+        let value_selector = StaticValueSelector::new(values.clone());
         let placer = QueuedEntityPlacer::new(
             entity_selector,
             value_selector,

--- a/crates/solverforge-solver/src/builder/basic_selector.rs
+++ b/crates/solverforge-solver/src/builder/basic_selector.rs
@@ -8,7 +8,7 @@ use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::EitherMove;
 use crate::heuristic::selector::decorator::VecUnionSelector;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 use crate::heuristic::selector::{
     EitherChangeMoveSelector, EitherSwapMoveSelector, FromSolutionEntitySelector,
 };
@@ -27,7 +27,7 @@ pub enum BasicLeafSelector<S: PlanningSolution> {
             S,
             usize,
             FromSolutionEntitySelector,
-            crate::heuristic::selector::typed_value::StaticTypedValueSelector<S, usize>,
+            crate::heuristic::selector::value_selector::StaticValueSelector<S, usize>,
         >,
     ),
     // A swap move selector yielding `EitherMove::Swap`.

--- a/crates/solverforge-solver/src/builder/list_selector.rs
+++ b/crates/solverforge-solver/src/builder/list_selector.rs
@@ -9,11 +9,11 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::ListMoveImpl;
 use crate::heuristic::selector::decorator::VecUnionSelector;
 use crate::heuristic::selector::k_opt::KOptConfig;
-use crate::heuristic::selector::nearby_list_change::CrossEntityDistanceMeter;
-use crate::heuristic::selector::typed_move_selector::{
+use crate::heuristic::selector::move_selector::{
     ListMoveKOptSelector, ListMoveListChangeSelector, ListMoveListRuinSelector,
     ListMoveNearbyKOptSelector, MoveSelector,
 };
+use crate::heuristic::selector::nearby_list_change::CrossEntityDistanceMeter;
 
 use super::context::IntraDistanceAdapter;
 use crate::heuristic::selector::{

--- a/crates/solverforge-solver/src/heuristic/mod.rs
+++ b/crates/solverforge-solver/src/heuristic/mod.rs
@@ -22,7 +22,7 @@ pub use selector::{
     AllEntitiesSelector, ChangeMoveSelector, CrossEntityDistanceMeter,
     DefaultCrossEntityDistanceMeter, DefaultDistanceMeter, DefaultPillarSelector,
     EitherChangeMoveSelector, EitherSwapMoveSelector, EntityReference, EntitySelector,
-    FromSolutionEntitySelector, FromSolutionTypedValueSelector, KOptConfig, KOptMoveSelector,
+    FromSolutionEntitySelector, FromSolutionValueSelector, KOptConfig, KOptMoveSelector,
     ListChangeMoveSelector, ListMoveKOptSelector, ListMoveListChangeSelector,
     ListMoveListReverseSelector, ListMoveListRuinSelector, ListMoveListSwapSelector,
     ListMoveNearbyListChangeSelector, ListMoveNearbyListSwapSelector,
@@ -31,6 +31,6 @@ pub use selector::{
     MimicRecordingEntitySelector, MimicReplayingEntitySelector, MoveSelector, NearbyDistanceMeter,
     NearbyEntitySelector, NearbyKOptMoveSelector, NearbyListChangeMoveSelector,
     NearbyListSwapMoveSelector, NearbySelectionConfig, Pillar, PillarSelector, RuinMoveSelector,
-    SelectionOrder, StaticTypedValueSelector, SubListChangeMoveSelector, SubListSwapMoveSelector,
-    SubPillarConfig, SwapMoveSelector, TypedValueSelector,
+    SelectionOrder, StaticValueSelector, SubListChangeMoveSelector, SubListSwapMoveSelector,
+    SubPillarConfig, SwapMoveSelector, ValueSelector,
 };

--- a/crates/solverforge-solver/src/heuristic/move/k_opt_tests.rs
+++ b/crates/solverforge-solver/src/heuristic/move/k_opt_tests.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::heuristic::r#move::k_opt_reconnection::THREE_OPT_RECONNECTIONS;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{RecordingDirector, ScoreDirector};
@@ -56,7 +56,7 @@ fn sublist_insert(s: &mut TspSolution, entity_idx: usize, pos: usize, items: Vec
 
 fn create_director(tours: Vec<Tour>) -> ScoreDirector<TspSolution, ()> {
     let solution = TspSolution { tours, score: None };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Tour",
         "tours",
         get_tours,

--- a/crates/solverforge-solver/src/heuristic/move/list_change_tests.rs
+++ b/crates/solverforge-solver/src/heuristic/move/list_change_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{RecordingDirector, ScoreDirector};
@@ -53,7 +53,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/sublist_change_tests.rs
+++ b/crates/solverforge-solver/src/heuristic/move/sublist_change_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{RecordingDirector, ScoreDirector};
@@ -63,7 +63,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/sublist_swap_tests.rs
+++ b/crates/solverforge-solver/src/heuristic/move/sublist_swap_tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{RecordingDirector, ScoreDirector};
@@ -63,7 +63,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/tests/k_opt.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/k_opt.rs
@@ -65,7 +65,7 @@ mod k_opt_tests {
 
     fn create_director(tours: Vec<Tour>) -> ScoreDirector<TspSolution, ()> {
         let solution = TspSolution { tours, score: None };
-        let extractor = Box::new(TypedEntityExtractor::new(
+        let extractor = Box::new(EntityCollectionExtractor::new(
             "Tour",
             "tours",
             get_tours,

--- a/crates/solverforge-solver/src/heuristic/move/tests/list_change.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/list_change.rs
@@ -47,7 +47,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/tests/list_reverse.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/list_reverse.rs
@@ -41,7 +41,7 @@ fn list_reverse(s: &mut TspSolution, entity_idx: usize, start: usize, end: usize
 
 fn create_director(tours: Vec<Tour>) -> ScoreDirector<TspSolution, ()> {
     let solution = TspSolution { tours, score: None };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Tour",
         "tours",
         get_tours,

--- a/crates/solverforge-solver/src/heuristic/move/tests/list_ruin.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/list_ruin.rs
@@ -54,7 +54,7 @@ fn create_director(stops: Vec<i32>) -> ScoreDirector<VrpSolution, ()> {
         routes,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Route",
         "routes",
         get_routes,

--- a/crates/solverforge-solver/src/heuristic/move/tests/list_swap.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/list_swap.rs
@@ -51,7 +51,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/tests/mod.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/mod.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{Director, RecordingDirector, ScoreDirector};

--- a/crates/solverforge-solver/src/heuristic/move/tests/pillar_change.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/pillar_change.rs
@@ -40,7 +40,7 @@ fn create_director(employees: Vec<Employee>) -> ScoreDirector<ScheduleSolution, 
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Employee",
         "employees",
         |s: &ScheduleSolution| &s.employees,

--- a/crates/solverforge-solver/src/heuristic/move/tests/pillar_swap.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/pillar_swap.rs
@@ -39,7 +39,7 @@ fn create_director(employees: Vec<Employee>) -> ScoreDirector<Solution, ()> {
         employees,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Employee",
         "employees",
         |s: &Solution| &s.employees,

--- a/crates/solverforge-solver/src/heuristic/move/tests/ruin.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/ruin.rs
@@ -45,7 +45,7 @@ fn create_director(assignments: &[Option<i32>]) -> ScoreDirector<Schedule, ()> {
         .map(|&a| Task { assigned_to: a })
         .collect();
     let solution = Schedule { tasks, score: None };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,

--- a/crates/solverforge-solver/src/heuristic/move/tests/sublist_change.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/sublist_change.rs
@@ -57,7 +57,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/tests/sublist_swap.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/sublist_swap.rs
@@ -57,7 +57,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<RoutingSolution, ()>
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/move/tests/swap.rs
+++ b/crates/solverforge-solver/src/heuristic/move/tests/swap.rs
@@ -45,7 +45,7 @@ fn set_priority(s: &mut TaskSolution, idx: usize, v: Option<i32>) {
 fn create_director(tasks: Vec<Task>) -> ScoreDirector<TaskSolution, ()> {
     let solution = TaskSolution { tasks, score: None };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/cartesian_product.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/cartesian_product.rs
@@ -140,7 +140,9 @@ mod tests {
     use super::*;
     use crate::heuristic::r#move::ChangeMove;
     use crate::heuristic::selector::ChangeMoveSelector;
-    use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, TypedEntityExtractor};
+    use solverforge_core::domain::{
+        EntityCollectionExtractor, EntityDescriptor, SolutionDescriptor,
+    };
     use solverforge_core::score::SoftScore;
     use solverforge_scoring::ScoreDirector;
     use std::any::TypeId;
@@ -192,7 +194,7 @@ mod tests {
 
     fn create_director(tasks: Vec<Task>) -> ScoreDirector<Sol, ()> {
         let solution = Sol { tasks, score: None };
-        let extractor = Box::new(TypedEntityExtractor::new(
+        let extractor = Box::new(EntityCollectionExtractor::new(
             "Task",
             "tasks",
             get_tasks,

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/count_limit.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/count_limit.rs
@@ -10,7 +10,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Limits the number of moves yielded from an inner selector.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/filtering.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/filtering.rs
@@ -10,7 +10,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Filters moves from an inner selector using a predicate function.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/probability.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/probability.rs
@@ -14,7 +14,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Probabilistically filters moves from an inner selector.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/shuffling.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/shuffling.rs
@@ -15,7 +15,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Shuffles moves from an inner selector randomly.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/sorting.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/sorting.rs
@@ -11,7 +11,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Sorts moves from an inner selector using a comparator function.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/union.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/union.rs
@@ -10,7 +10,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Combines moves from two selectors into a single stream.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/decorator/vec_union.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/decorator/vec_union.rs
@@ -13,7 +13,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 
 /// Combines moves from an arbitrary number of leaf selectors into a single stream.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/k_opt/nearby.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/k_opt/nearby.rs
@@ -12,7 +12,7 @@ use crate::heuristic::r#move::k_opt_reconnection::{
 use crate::heuristic::r#move::{CutPoint, KOptMove};
 
 use super::super::entity::EntitySelector;
-use super::super::typed_move_selector::MoveSelector;
+use super::super::move_selector::MoveSelector;
 use super::config::KOptConfig;
 use super::distance_meter::ListPositionDistanceMeter;
 

--- a/crates/solverforge-solver/src/heuristic/selector/k_opt/selector.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/k_opt/selector.rs
@@ -13,7 +13,7 @@ use crate::heuristic::r#move::k_opt_reconnection::{
 use crate::heuristic::r#move::KOptMove;
 
 use super::super::entity::EntitySelector;
-use super::super::typed_move_selector::MoveSelector;
+use super::super::move_selector::MoveSelector;
 use super::config::KOptConfig;
 use super::iterators::count_cut_combinations;
 use super::iterators::CutCombinationIterator;

--- a/crates/solverforge-solver/src/heuristic/selector/k_opt/tests.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/k_opt/tests.rs
@@ -3,9 +3,9 @@
 use super::*;
 use crate::heuristic::r#move::Move;
 use crate::heuristic::selector::entity::FromSolutionEntitySelector;
-use crate::heuristic::selector::typed_move_selector::MoveSelector;
+use crate::heuristic::selector::move_selector::MoveSelector;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -57,7 +57,7 @@ fn sublist_insert(s: &mut TspSolution, entity_idx: usize, pos: usize, items: Vec
 
 fn create_director(tours: Vec<Tour>) -> ScoreDirector<TspSolution, ()> {
     let solution = TspSolution { tours, score: None };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Tour",
         "tours",
         get_tours,

--- a/crates/solverforge-solver/src/heuristic/selector/list_change.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/list_change.rs
@@ -54,7 +54,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::ListChangeMove;
 
 use super::entity::EntitySelector;
-use super::typed_move_selector::MoveSelector;
+use super::move_selector::MoveSelector;
 
 /// A move selector that generates list change moves.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/list_reverse.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/list_reverse.rs
@@ -62,7 +62,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ListMoveImpl, ListReverseMove};
 
 use super::entity::EntitySelector;
-use super::typed_move_selector::MoveSelector;
+use super::move_selector::MoveSelector;
 
 /// A move selector that generates 2-opt segment reversal moves.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/list_swap.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/list_swap.rs
@@ -63,7 +63,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ListMoveImpl, ListSwapMove};
 
 use super::entity::EntitySelector;
-use super::typed_move_selector::MoveSelector;
+use super::move_selector::MoveSelector;
 
 /// A move selector that generates list swap moves.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/mod.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/mod.rs
@@ -12,6 +12,7 @@ pub mod list_reverse;
 pub mod list_ruin;
 pub mod list_swap;
 pub mod mimic;
+pub mod move_selector;
 pub mod nearby;
 pub mod nearby_list_change;
 pub mod nearby_list_swap;
@@ -20,8 +21,7 @@ pub mod ruin;
 mod selection_order;
 pub mod sublist_change;
 pub mod sublist_swap;
-pub mod typed_move_selector;
-pub mod typed_value;
+pub mod value_selector;
 
 #[cfg(test)]
 mod tests;
@@ -38,6 +38,11 @@ pub use list_reverse::{ListMoveListReverseSelector, ListReverseMoveSelector};
 pub use list_ruin::ListRuinMoveSelector;
 pub use list_swap::{ListMoveListSwapSelector, ListSwapMoveSelector};
 pub use mimic::{MimicRecorder, MimicRecordingEntitySelector, MimicReplayingEntitySelector};
+pub use move_selector::{
+    ChangeMoveSelector, EitherChangeMoveSelector, EitherSwapMoveSelector, ListMoveKOptSelector,
+    ListMoveListChangeSelector, ListMoveListRuinSelector, ListMoveNearbyKOptSelector, MoveSelector,
+    SwapMoveSelector,
+};
 pub use nearby::{NearbyDistanceMeter, NearbyEntitySelector, NearbySelectionConfig};
 pub use nearby_list_change::{
     CrossEntityDistanceMeter, DefaultCrossEntityDistanceMeter, ListMoveNearbyListChangeSelector,
@@ -49,11 +54,4 @@ pub use ruin::RuinMoveSelector;
 pub use selection_order::SelectionOrder;
 pub use sublist_change::{ListMoveSubListChangeSelector, SubListChangeMoveSelector};
 pub use sublist_swap::{ListMoveSubListSwapSelector, SubListSwapMoveSelector};
-pub use typed_move_selector::{
-    ChangeMoveSelector, EitherChangeMoveSelector, EitherSwapMoveSelector, ListMoveKOptSelector,
-    ListMoveListChangeSelector, ListMoveListRuinSelector, ListMoveNearbyKOptSelector, MoveSelector,
-    SwapMoveSelector,
-};
-pub use typed_value::{
-    FromSolutionTypedValueSelector, StaticTypedValueSelector, TypedValueSelector,
-};
+pub use value_selector::{FromSolutionValueSelector, StaticValueSelector, ValueSelector};

--- a/crates/solverforge-solver/src/heuristic/selector/move_selector.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/move_selector.rs
@@ -13,7 +13,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ChangeMove, EitherMove, ListMoveImpl, Move, SwapMove};
 
 use super::entity::{EntityReference, EntitySelector, FromSolutionEntitySelector};
-use super::typed_value::{StaticTypedValueSelector, TypedValueSelector};
+use super::value_selector::{StaticValueSelector, ValueSelector};
 
 /// A typed move selector that yields moves of type `M` directly.
 ///
@@ -93,7 +93,7 @@ impl<S: PlanningSolution, V: Clone, ES, VS> ChangeMoveSelector<S, V, ES, VS> {
 }
 
 impl<S: PlanningSolution, V: Clone + Send + Sync + Debug + 'static>
-    ChangeMoveSelector<S, V, FromSolutionEntitySelector, StaticTypedValueSelector<S, V>>
+    ChangeMoveSelector<S, V, FromSolutionEntitySelector, StaticValueSelector<S, V>>
 {
     pub fn simple(
         getter: fn(&S, usize) -> Option<V>,
@@ -104,7 +104,7 @@ impl<S: PlanningSolution, V: Clone + Send + Sync + Debug + 'static>
     ) -> Self {
         Self {
             entity_selector: FromSolutionEntitySelector::new(descriptor_index),
-            value_selector: StaticTypedValueSelector::new(values),
+            value_selector: StaticValueSelector::new(values),
             getter,
             setter,
             descriptor_index,
@@ -119,7 +119,7 @@ where
     S: PlanningSolution,
     V: Clone + PartialEq + Send + Sync + Debug + 'static,
     ES: EntitySelector<S>,
-    VS: TypedValueSelector<S, V>,
+    VS: ValueSelector<S, V>,
 {
     fn iter_moves<'a, D: Director<S>>(
         &'a self,
@@ -324,7 +324,7 @@ impl<S, V: Debug, ES: Debug, VS: Debug> Debug for EitherChangeMoveSelector<S, V,
 }
 
 impl<S: PlanningSolution, V: Clone + Send + Sync + Debug + 'static>
-    EitherChangeMoveSelector<S, V, FromSolutionEntitySelector, StaticTypedValueSelector<S, V>>
+    EitherChangeMoveSelector<S, V, FromSolutionEntitySelector, StaticValueSelector<S, V>>
 {
     pub fn simple(
         getter: fn(&S, usize) -> Option<V>,
@@ -350,7 +350,7 @@ where
     S: PlanningSolution,
     V: Clone + PartialEq + Send + Sync + Debug + 'static,
     ES: EntitySelector<S>,
-    VS: TypedValueSelector<S, V>,
+    VS: ValueSelector<S, V>,
 {
     fn iter_moves<'a, D: Director<S>>(
         &'a self,
@@ -591,5 +591,5 @@ sublist_swap.rs, list_reverse.rs) alongside the selectors they wrap.
 */
 
 #[cfg(test)]
-#[path = "typed_move_selector_tests.rs"]
+#[path = "move_selector_tests.rs"]
 mod tests;

--- a/crates/solverforge-solver/src/heuristic/selector/move_selector_tests.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/move_selector_tests.rs
@@ -1,16 +1,12 @@
 // Tests for typed move selectors.
 
+use super::*;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
-use solverforge_scoring::{Director, RecordingDirector, ScoreDirector};
+use solverforge_scoring::{RecordingDirector, ScoreDirector};
 use std::any::TypeId;
-
-use crate::heuristic::r#move::Move;
-use crate::heuristic::selector::typed_move_selector::{
-    ChangeMoveSelector, MoveSelector, SwapMoveSelector,
-};
 
 #[derive(Clone, Debug)]
 struct Task {
@@ -57,7 +53,7 @@ fn set_priority(s: &mut TaskSolution, idx: usize, v: Option<i32>) {
 fn create_director(tasks: Vec<Task>) -> ScoreDirector<TaskSolution, ()> {
     let solution = TaskSolution { tasks, score: None };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,

--- a/crates/solverforge-solver/src/heuristic/selector/nearby_list_change.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/nearby_list_change.rs
@@ -99,7 +99,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ListChangeMove, ListMoveImpl};
 
 use super::entity::EntitySelector;
-use super::typed_move_selector::MoveSelector;
+use super::move_selector::MoveSelector;
 
 /// Measures distance between two list positions, potentially across different entities.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/nearby_list_swap.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/nearby_list_swap.rs
@@ -81,8 +81,8 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ListMoveImpl, ListSwapMove};
 
 use super::entity::EntitySelector;
+use super::move_selector::MoveSelector;
 use super::nearby_list_change::CrossEntityDistanceMeter;
-use super::typed_move_selector::MoveSelector;
 
 /// A distance-pruned list swap move selector.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/pillar_tests.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/pillar_tests.rs
@@ -3,7 +3,7 @@
 use super::*;
 use crate::heuristic::selector::entity::FromSolutionEntitySelector;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -47,7 +47,7 @@ fn create_test_director(employees: Vec<Employee>) -> ScoreDirector<ScheduleSolut
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Employee",
         "employees",
         get_employees,

--- a/crates/solverforge-solver/src/heuristic/selector/sublist_change.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/sublist_change.rs
@@ -73,7 +73,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ListMoveImpl, SubListChangeMove};
 
 use super::entity::EntitySelector;
-use super::typed_move_selector::MoveSelector;
+use super::move_selector::MoveSelector;
 
 /// A move selector that generates sublist change (Or-opt) moves.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/sublist_swap.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/sublist_swap.rs
@@ -70,7 +70,7 @@ use solverforge_scoring::Director;
 use crate::heuristic::r#move::{ListMoveImpl, SubListSwapMove};
 
 use super::entity::EntitySelector;
-use super::typed_move_selector::MoveSelector;
+use super::move_selector::MoveSelector;
 
 /// A move selector that generates sublist swap moves.
 ///

--- a/crates/solverforge-solver/src/heuristic/selector/tests/k_opt.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/k_opt.rs
@@ -1,7 +1,7 @@
 // Tests for k-opt move selector.
 
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -60,7 +60,7 @@ fn sublist_insert(s: &mut TspSolution, entity_idx: usize, pos: usize, items: Vec
 
 fn create_director(tours: Vec<Tour>) -> ScoreDirector<TspSolution, ()> {
     let solution = TspSolution { tours, score: None };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Tour",
         "tours",
         get_tours,

--- a/crates/solverforge-solver/src/heuristic/selector/tests/list_change.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/list_change.rs
@@ -5,7 +5,7 @@ use crate::heuristic::selector::entity::FromSolutionEntitySelector;
 use crate::heuristic::selector::list_change::ListChangeMoveSelector;
 use crate::heuristic::selector::MoveSelector;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -56,7 +56,7 @@ fn create_director(vehicles: Vec<Vehicle>) -> ScoreDirector<Solution, ()> {
         vehicles,
         score: None,
     };
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Vehicle",
         "vehicles",
         get_vehicles,

--- a/crates/solverforge-solver/src/heuristic/selector/tests/mimic.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/mimic.rs
@@ -1,7 +1,7 @@
 // Tests for mimic selectors.
 
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -53,7 +53,7 @@ fn create_test_director(n: usize) -> ScoreDirector<NQueensSolution, ()> {
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Queen",
         "queens",
         get_queens,

--- a/crates/solverforge-solver/src/heuristic/selector/tests/mod.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/mod.rs
@@ -9,6 +9,6 @@ mod k_opt;
 mod list_change;
 mod list_ruin;
 mod mimic;
+mod move_selector;
 mod nearby;
 mod pillar;
-mod typed_move_selector;

--- a/crates/solverforge-solver/src/heuristic/selector/tests/move_selector.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/move_selector.rs
@@ -1,12 +1,16 @@
 // Tests for typed move selectors.
 
-use super::*;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
-use solverforge_scoring::{RecordingDirector, ScoreDirector};
+use solverforge_scoring::{Director, RecordingDirector, ScoreDirector};
 use std::any::TypeId;
+
+use crate::heuristic::r#move::Move;
+use crate::heuristic::selector::move_selector::{
+    ChangeMoveSelector, MoveSelector, SwapMoveSelector,
+};
 
 #[derive(Clone, Debug)]
 struct Task {
@@ -53,7 +57,7 @@ fn set_priority(s: &mut TaskSolution, idx: usize, v: Option<i32>) {
 fn create_director(tasks: Vec<Task>) -> ScoreDirector<TaskSolution, ()> {
     let solution = TaskSolution { tasks, score: None };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,

--- a/crates/solverforge-solver/src/heuristic/selector/tests/nearby.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/nearby.rs
@@ -7,7 +7,7 @@ use crate::heuristic::selector::nearby::{
 };
 use crate::heuristic::selector::{EntityReference, EntitySelector};
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{Director, ScoreDirector};
@@ -116,7 +116,7 @@ fn create_test_director() -> ScoreDirector<RoutingSolution, ()> {
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Location",
         "locations",
         get_locations,

--- a/crates/solverforge-solver/src/heuristic/selector/tests/pillar.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/tests/pillar.rs
@@ -5,7 +5,7 @@ use crate::heuristic::selector::entity::FromSolutionEntitySelector;
 use crate::heuristic::selector::pillar::{
     DefaultPillarSelector, Pillar, PillarSelector, SubPillarConfig,
 };
-use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, TypedEntityExtractor};
+use solverforge_core::domain::{EntityCollectionExtractor, EntityDescriptor, SolutionDescriptor};
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
 use std::any::TypeId;
@@ -48,7 +48,7 @@ fn create_test_director(employees: Vec<Employee>) -> ScoreDirector<ScheduleSolut
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Employee",
         "employees",
         get_employees,

--- a/crates/solverforge-solver/src/heuristic/selector/value_selector.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/value_selector.rs
@@ -18,7 +18,7 @@ use solverforge_scoring::Director;
 /// # Type Parameters
 /// * `S` - The planning solution type
 /// * `V` - The value type
-pub trait TypedValueSelector<S: PlanningSolution, V>: Send + Debug {
+pub trait ValueSelector<S: PlanningSolution, V>: Send + Debug {
     // Returns an iterator over typed values for the given entity.
     fn iter_typed<'a, D: Director<S>>(
         &'a self,
@@ -41,12 +41,12 @@ pub trait TypedValueSelector<S: PlanningSolution, V>: Send + Debug {
 }
 
 /// A typed value selector with a static list of values.
-pub struct StaticTypedValueSelector<S, V> {
+pub struct StaticValueSelector<S, V> {
     values: Vec<V>,
     _phantom: PhantomData<fn() -> S>,
 }
 
-impl<S, V: Clone> Clone for StaticTypedValueSelector<S, V> {
+impl<S, V: Clone> Clone for StaticValueSelector<S, V> {
     fn clone(&self) -> Self {
         Self {
             values: self.values.clone(),
@@ -55,15 +55,15 @@ impl<S, V: Clone> Clone for StaticTypedValueSelector<S, V> {
     }
 }
 
-impl<S, V: Debug> Debug for StaticTypedValueSelector<S, V> {
+impl<S, V: Debug> Debug for StaticValueSelector<S, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StaticTypedValueSelector")
+        f.debug_struct("StaticValueSelector")
             .field("values", &self.values)
             .finish()
     }
 }
 
-impl<S, V: Clone> StaticTypedValueSelector<S, V> {
+impl<S, V: Clone> StaticValueSelector<S, V> {
     pub fn new(values: Vec<V>) -> Self {
         Self {
             values,
@@ -76,7 +76,7 @@ impl<S, V: Clone> StaticTypedValueSelector<S, V> {
     }
 }
 
-impl<S, V> TypedValueSelector<S, V> for StaticTypedValueSelector<S, V>
+impl<S, V> ValueSelector<S, V> for StaticValueSelector<S, V>
 where
     S: PlanningSolution,
     V: Clone + Send + Debug + 'static,
@@ -101,18 +101,18 @@ where
 }
 
 /// A typed value selector that extracts values from the solution using a function pointer.
-pub struct FromSolutionTypedValueSelector<S, V> {
+pub struct FromSolutionValueSelector<S, V> {
     extractor: fn(&S) -> Vec<V>,
     _phantom: PhantomData<(fn() -> S, fn() -> V)>,
 }
 
-impl<S, V> Debug for FromSolutionTypedValueSelector<S, V> {
+impl<S, V> Debug for FromSolutionValueSelector<S, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FromSolutionTypedValueSelector").finish()
+        f.debug_struct("FromSolutionValueSelector").finish()
     }
 }
 
-impl<S, V> FromSolutionTypedValueSelector<S, V> {
+impl<S, V> FromSolutionValueSelector<S, V> {
     pub fn new(extractor: fn(&S) -> Vec<V>) -> Self {
         Self {
             extractor,
@@ -121,7 +121,7 @@ impl<S, V> FromSolutionTypedValueSelector<S, V> {
     }
 }
 
-impl<S, V> TypedValueSelector<S, V> for FromSolutionTypedValueSelector<S, V>
+impl<S, V> ValueSelector<S, V> for FromSolutionValueSelector<S, V>
 where
     S: PlanningSolution,
     V: Clone + Send + Debug + 'static,
@@ -169,7 +169,7 @@ impl<S> RangeValueSelector<S> {
     }
 }
 
-impl<S> TypedValueSelector<S, usize> for RangeValueSelector<S>
+impl<S> ValueSelector<S, usize> for RangeValueSelector<S>
 where
     S: PlanningSolution,
 {
@@ -196,7 +196,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, TypedEntityExtractor};
+    use solverforge_core::domain::{
+        EntityCollectionExtractor, EntityDescriptor, SolutionDescriptor,
+    };
     use solverforge_core::score::SoftScore;
     use solverforge_scoring::ScoreDirector;
     use std::any::TypeId;
@@ -225,7 +227,7 @@ mod tests {
 
     fn create_director(tasks: Vec<Task>) -> ScoreDirector<TaskSolution, ()> {
         let solution = TaskSolution { tasks, score: None };
-        let extractor = Box::new(TypedEntityExtractor::new(
+        let extractor = Box::new(EntityCollectionExtractor::new(
             "Task",
             "tasks",
             |s: &TaskSolution| &s.tasks,
@@ -239,12 +241,12 @@ mod tests {
     }
 
     #[test]
-    fn test_static_typed_value_selector() {
+    fn test_static_value_selector_selector() {
         let director = create_director(vec![Task {
             id: 0,
             priority: None,
         }]);
-        let selector = StaticTypedValueSelector::<TaskSolution, i32>::new(vec![1, 2, 3, 4, 5]);
+        let selector = StaticValueSelector::<TaskSolution, i32>::new(vec![1, 2, 3, 4, 5]);
 
         let values: Vec<_> = selector.iter_typed(&director, 0, 0).collect();
         assert_eq!(values, vec![1, 2, 3, 4, 5]);
@@ -252,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_solution_typed_value_selector() {
+    fn test_from_solution_value_selector_selector() {
         let director = create_director(vec![
             Task {
                 id: 0,
@@ -274,7 +276,7 @@ mod tests {
             s.tasks.iter().filter_map(|t| t.priority).collect()
         }
 
-        let selector = FromSolutionTypedValueSelector::new(extract_priorities);
+        let selector = FromSolutionValueSelector::new(extract_priorities);
 
         let values: Vec<_> = selector.iter_typed(&director, 0, 0).collect();
         assert_eq!(values, vec![10, 20]);

--- a/crates/solverforge-solver/src/lib.rs
+++ b/crates/solverforge-solver/src/lib.rs
@@ -53,7 +53,7 @@ pub use heuristic::{
     EntityReference,
     EntitySelector,
     FromSolutionEntitySelector,
-    FromSolutionTypedValueSelector,
+    FromSolutionValueSelector,
     KOptConfig,
     KOptMove,
     KOptMoveSelector,
@@ -77,11 +77,11 @@ pub use heuristic::{
     RuinMove,
     RuinMoveSelector,
     SelectionOrder,
-    StaticTypedValueSelector,
+    StaticValueSelector,
     SubPillarConfig,
     SwapMove,
     SwapMoveSelector,
-    TypedValueSelector,
+    ValueSelector,
     // Vec union selector
     VecUnionSelector,
 };

--- a/crates/solverforge-solver/src/manager/phase_factory/k_opt.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/k_opt.rs
@@ -194,7 +194,7 @@ where
     fn solve(&mut self, solver_scope: &mut SolverScope<S, D>) {
         use crate::heuristic::r#move::Move;
         use crate::heuristic::selector::entity::FromSolutionEntitySelector;
-        use crate::heuristic::selector::typed_move_selector::MoveSelector;
+        use crate::heuristic::selector::move_selector::MoveSelector;
 
         let mut phase_scope = PhaseScope::new(solver_scope, 0);
 

--- a/crates/solverforge-solver/src/manager/phase_factory_tests.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory_tests.rs
@@ -2,10 +2,10 @@
 
 use super::*;
 use crate::heuristic::r#move::ChangeMove;
-use crate::heuristic::selector::{FromSolutionEntitySelector, StaticTypedValueSelector};
+use crate::heuristic::selector::{FromSolutionEntitySelector, StaticValueSelector};
 use crate::phase::construction::{EntityPlacer, ForagerType, QueuedEntityPlacer};
 use crate::scope::SolverScope;
-use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, TypedEntityExtractor};
+use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, EntityCollectionExtractor};
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{Director, ScoreDirector};
 use std::any::TypeId;
@@ -72,7 +72,7 @@ fn create_test_director(
 ) -> ScoreDirector<TestSolution, ()> {
     let solution = TestSolution { tasks, score: None };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,
@@ -103,14 +103,14 @@ type TestPlacer = QueuedEntityPlacer<
     TestSolution,
     i64,
     FromSolutionEntitySelector,
-    StaticTypedValueSelector<TestSolution, i64>,
+    StaticValueSelector<TestSolution, i64>,
 >;
 
 fn create_placer_factory() -> impl Fn() -> TestPlacer + Send + Sync {
     || {
         QueuedEntityPlacer::new(
             FromSolutionEntitySelector::new(0),
-            StaticTypedValueSelector::new(vec![1i64, 2, 3, 4, 5]),
+            StaticValueSelector::new(vec![1i64, 2, 3, 4, 5]),
             get_task_priority,
             set_task_priority,
             0,

--- a/crates/solverforge-solver/src/manager/phase_factory_tests_localsearch.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory_tests_localsearch.rs
@@ -3,12 +3,12 @@
 use super::*;
 use crate::heuristic::r#move::ChangeMove;
 use crate::heuristic::selector::{
-    ChangeMoveSelector, FromSolutionEntitySelector, StaticTypedValueSelector,
+    ChangeMoveSelector, FromSolutionEntitySelector, StaticValueSelector,
 };
 use crate::heuristic::MoveSelector;
 use crate::phase::construction::{EntityPlacer, QueuedEntityPlacer};
 use crate::scope::SolverScope;
-use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, TypedEntityExtractor};
+use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, EntityCollectionExtractor};
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::{Director, ScoreDirector};
 use std::any::TypeId;
@@ -74,7 +74,7 @@ fn create_test_director(
 ) -> ScoreDirector<TestSolution, ()> {
     let solution = TestSolution { tasks, score: None };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,
@@ -118,14 +118,14 @@ type TestPlacer = QueuedEntityPlacer<
     TestSolution,
     i64,
     FromSolutionEntitySelector,
-    StaticTypedValueSelector<TestSolution, i64>,
+    StaticValueSelector<TestSolution, i64>,
 >;
 
 fn create_placer_factory() -> impl Fn() -> TestPlacer + Send + Sync {
     || {
         QueuedEntityPlacer::new(
             FromSolutionEntitySelector::new(0),
-            StaticTypedValueSelector::new(vec![1i64, 2, 3, 4, 5]),
+            StaticValueSelector::new(vec![1i64, 2, 3, 4, 5]),
             get_task_priority,
             set_task_priority,
             0,
@@ -138,7 +138,7 @@ type TestMoveSelector = ChangeMoveSelector<
     TestSolution,
     i64,
     FromSolutionEntitySelector,
-    StaticTypedValueSelector<TestSolution, i64>,
+    StaticValueSelector<TestSolution, i64>,
 >;
 
 fn create_move_selector_factory() -> impl Fn() -> TestMoveSelector + Send + Sync {

--- a/crates/solverforge-solver/src/phase/construction/forager_tests.rs
+++ b/crates/solverforge-solver/src/phase/construction/forager_tests.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::heuristic::r#move::ChangeMove;
 use crate::heuristic::selector::EntityReference;
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -57,7 +57,7 @@ fn create_test_director() -> ScoreDirector<NQueensSolution, ()> {
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Queen",
         "queens",
         get_queens,

--- a/crates/solverforge-solver/src/phase/construction/phase.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase.rs
@@ -167,7 +167,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::heuristic::selector::{FromSolutionEntitySelector, StaticTypedValueSelector};
+    use crate::heuristic::selector::{FromSolutionEntitySelector, StaticValueSelector};
     use crate::phase::construction::{BestFitForager, FirstFitForager, QueuedEntityPlacer};
     use crate::test_utils::{
         create_simple_nqueens_director, get_queen_row, set_queen_row, NQueensSolution,
@@ -179,10 +179,10 @@ mod tests {
         NQueensSolution,
         i64,
         FromSolutionEntitySelector,
-        StaticTypedValueSelector<NQueensSolution, i64>,
+        StaticValueSelector<NQueensSolution, i64>,
     > {
         let es = FromSolutionEntitySelector::new(0);
-        let vs = StaticTypedValueSelector::new(values);
+        let vs = StaticValueSelector::new(values);
         QueuedEntityPlacer::new(es, vs, get_queen_row, set_queen_row, 0, "row")
     }
 

--- a/crates/solverforge-solver/src/phase/construction/placer.rs
+++ b/crates/solverforge-solver/src/phase/construction/placer.rs
@@ -11,7 +11,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use crate::heuristic::r#move::{ChangeMove, Move};
-use crate::heuristic::selector::{EntityReference, EntitySelector, TypedValueSelector};
+use crate::heuristic::selector::{EntityReference, EntitySelector, ValueSelector};
 
 /// A placement represents an entity that needs a value assigned,
 /// along with the candidate moves to assign values.
@@ -100,7 +100,7 @@ pub struct QueuedEntityPlacer<S, V, ES, VS>
 where
     S: PlanningSolution,
     ES: EntitySelector<S>,
-    VS: TypedValueSelector<S, V>,
+    VS: ValueSelector<S, V>,
 {
     // The entity selector.
     entity_selector: ES,
@@ -121,7 +121,7 @@ impl<S, V, ES, VS> QueuedEntityPlacer<S, V, ES, VS>
 where
     S: PlanningSolution,
     ES: EntitySelector<S>,
-    VS: TypedValueSelector<S, V>,
+    VS: ValueSelector<S, V>,
 {
     pub fn new(
         entity_selector: ES,
@@ -147,7 +147,7 @@ impl<S, V, ES, VS> Debug for QueuedEntityPlacer<S, V, ES, VS>
 where
     S: PlanningSolution,
     ES: EntitySelector<S> + Debug,
-    VS: TypedValueSelector<S, V> + Debug,
+    VS: ValueSelector<S, V> + Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueuedEntityPlacer")
@@ -163,7 +163,7 @@ where
     S: PlanningSolution,
     V: Clone + PartialEq + Send + Sync + Debug + 'static,
     ES: EntitySelector<S>,
-    VS: TypedValueSelector<S, V>,
+    VS: ValueSelector<S, V>,
 {
     fn get_placements<D: Director<S>>(
         &self,
@@ -226,7 +226,7 @@ where
 /// ```
 /// use solverforge_solver::phase::construction::{SortedEntityPlacer, QueuedEntityPlacer, EntityPlacer};
 /// use solverforge_solver::heuristic::r#move::ChangeMove;
-/// use solverforge_solver::heuristic::selector::{FromSolutionEntitySelector, StaticTypedValueSelector};
+/// use solverforge_solver::heuristic::selector::{FromSolutionEntitySelector, StaticValueSelector};
 /// use solverforge_core::domain::PlanningSolution;
 /// use solverforge_core::score::SoftScore;
 /// use solverforge_scoring::ScoreDirector;

--- a/crates/solverforge-solver/src/phase/construction/placer_tests.rs
+++ b/crates/solverforge-solver/src/phase/construction/placer_tests.rs
@@ -1,9 +1,9 @@
 // Tests for entity placers.
 
 use super::*;
-use crate::heuristic::selector::{FromSolutionEntitySelector, StaticTypedValueSelector};
+use crate::heuristic::selector::{FromSolutionEntitySelector, StaticValueSelector};
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
@@ -66,7 +66,7 @@ fn create_test_director(initialized: &[bool]) -> ScoreDirector<NQueensSolution, 
         score: None,
     };
 
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Queen",
         "queens",
         get_queens,
@@ -86,7 +86,7 @@ fn test_queued_placer_all_uninitialized() {
     let director = create_test_director(&[false, false, false]);
 
     let entity_selector = FromSolutionEntitySelector::new(0);
-    let value_selector = StaticTypedValueSelector::new(vec![0i32, 1, 2]);
+    let value_selector = StaticValueSelector::new(vec![0i32, 1, 2]);
 
     let placer = QueuedEntityPlacer::new(
         entity_selector,
@@ -114,7 +114,7 @@ fn test_queued_placer_some_initialized() {
     let director = create_test_director(&[true, false, true]);
 
     let entity_selector = FromSolutionEntitySelector::new(0);
-    let value_selector = StaticTypedValueSelector::new(vec![0i32, 1, 2]);
+    let value_selector = StaticValueSelector::new(vec![0i32, 1, 2]);
 
     let placer = QueuedEntityPlacer::new(
         entity_selector,
@@ -137,7 +137,7 @@ fn test_queued_placer_all_initialized() {
     let director = create_test_director(&[true, true, true]);
 
     let entity_selector = FromSolutionEntitySelector::new(0);
-    let value_selector = StaticTypedValueSelector::new(vec![0i32, 1, 2]);
+    let value_selector = StaticValueSelector::new(vec![0i32, 1, 2]);
 
     let placer = QueuedEntityPlacer::new(
         entity_selector,
@@ -160,7 +160,7 @@ fn test_sorted_entity_placer_descending() {
     let director = create_test_director(&[false, false, false]);
 
     let entity_selector = FromSolutionEntitySelector::new(0);
-    let value_selector = StaticTypedValueSelector::new(vec![0i32, 1, 2]);
+    let value_selector = StaticValueSelector::new(vec![0i32, 1, 2]);
 
     let inner = QueuedEntityPlacer::new(
         entity_selector,

--- a/crates/solverforge-solver/src/phase/localsearch/phase.rs
+++ b/crates/solverforge-solver/src/phase/localsearch/phase.rs
@@ -443,7 +443,7 @@ mod tests {
         NQueensSolution,
         i64,
         crate::heuristic::selector::FromSolutionEntitySelector,
-        crate::heuristic::selector::StaticTypedValueSelector<NQueensSolution, i64>,
+        crate::heuristic::selector::StaticValueSelector<NQueensSolution, i64>,
     > {
         ChangeMoveSelector::simple(get_queen_row, set_queen_row, 0, "row", values)
     }

--- a/crates/solverforge-solver/src/phase/vnd/phase.rs
+++ b/crates/solverforge-solver/src/phase/vnd/phase.rs
@@ -244,7 +244,7 @@ mod tests {
         NQueensSolution,
         i64,
         crate::heuristic::selector::FromSolutionEntitySelector,
-        crate::heuristic::selector::StaticTypedValueSelector<NQueensSolution, i64>,
+        crate::heuristic::selector::StaticValueSelector<NQueensSolution, i64>,
     > {
         ChangeMoveSelector::simple(get_queen_row, set_queen_row, 0, "row", values)
     }

--- a/crates/solverforge-solver/src/realtime/problem_change.rs
+++ b/crates/solverforge-solver/src/realtime/problem_change.rs
@@ -172,7 +172,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use solverforge_core::domain::{EntityDescriptor, SolutionDescriptor, TypedEntityExtractor};
+    use solverforge_core::domain::{
+        EntityCollectionExtractor, EntityDescriptor, SolutionDescriptor,
+    };
     use solverforge_core::score::SoftScore;
     use solverforge_scoring::ScoreDirector;
     use std::any::TypeId;
@@ -207,7 +209,7 @@ mod tests {
 
     fn create_director(tasks: Vec<Task>) -> ScoreDirector<TaskSchedule, ()> {
         let solution = TaskSchedule { tasks, score: None };
-        let extractor = Box::new(TypedEntityExtractor::new(
+        let extractor = Box::new(EntityCollectionExtractor::new(
             "Task",
             "tasks",
             get_tasks,

--- a/crates/solverforge-test/src/entity.rs
+++ b/crates/solverforge-test/src/entity.rs
@@ -17,7 +17,8 @@ let descriptor = create_test_descriptor();
 */
 
 use solverforge_core::domain::{
-    EntityDescriptor, EntityExtractor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, EntityExtractor, PlanningSolution,
+    SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use std::any::TypeId;
@@ -115,7 +116,7 @@ pub fn set_entity_value(s: &mut TestSolution, idx: usize, v: Option<i32>) {
 }
 
 pub fn create_test_entity_extractor() -> Box<dyn EntityExtractor> {
-    Box::new(TypedEntityExtractor::new(
+    Box::new(EntityCollectionExtractor::new(
         "TestEntity",
         "entities",
         get_test_entities,

--- a/crates/solverforge-test/src/nqueens.rs
+++ b/crates/solverforge-test/src/nqueens.rs
@@ -17,7 +17,7 @@ assert_eq!(score, SoftScore::of(0)); // No conflicts
 */
 
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use std::any::TypeId;
@@ -178,7 +178,7 @@ pub fn calculate_conflicts(solution: &NQueensSolution) -> SoftScore {
 }
 
 pub fn create_nqueens_descriptor() -> SolutionDescriptor {
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Queen",
         "queens",
         get_queens,

--- a/crates/solverforge-test/src/task.rs
+++ b/crates/solverforge-test/src/task.rs
@@ -18,7 +18,7 @@ assert_eq!(solution.tasks.len(), 3);
 */
 
 use solverforge_core::domain::{
-    EntityDescriptor, PlanningSolution, SolutionDescriptor, TypedEntityExtractor,
+    EntityCollectionExtractor, EntityDescriptor, PlanningSolution, SolutionDescriptor,
 };
 use solverforge_core::score::SoftScore;
 use std::any::TypeId;
@@ -94,7 +94,7 @@ pub fn set_priority(s: &mut TaskSolution, idx: usize, v: Option<i32>) {
 }
 
 pub fn create_task_descriptor() -> SolutionDescriptor {
-    let extractor = Box::new(TypedEntityExtractor::new(
+    let extractor = Box::new(EntityCollectionExtractor::new(
         "Task",
         "tasks",
         get_tasks,

--- a/crates/solverforge/WIREFRAME.md
+++ b/crates/solverforge/WIREFRAME.md
@@ -138,7 +138,7 @@ Used exclusively by macro-generated code. Not public API.
 **Domain types (from `solverforge-core::domain`):**
 - `PlanningEntity`, `PlanningSolution`, `PlanningId`, `ProblemFact`
 - `EntityDescriptor`, `SolutionDescriptor`, `ProblemFactDescriptor`, `VariableDescriptor`
-- `TypedEntityExtractor`
+- `EntityCollectionExtractor`
 - `ShadowVariableKind`
 
 **Scoring (from `solverforge-scoring`):**

--- a/crates/solverforge/src/lib.rs
+++ b/crates/solverforge/src/lib.rs
@@ -143,8 +143,8 @@ pub mod __internal {
 
     // Domain types
     pub use solverforge_core::domain::{
-        EntityDescriptor, PlanningEntity, PlanningId, PlanningSolution, ProblemFact,
-        ProblemFactDescriptor, ShadowVariableKind, SolutionDescriptor, TypedEntityExtractor,
+        EntityCollectionExtractor, EntityDescriptor, PlanningEntity, PlanningId, PlanningSolution,
+        ProblemFact, ProblemFactDescriptor, ShadowVariableKind, SolutionDescriptor,
         VariableDescriptor,
     };
 


### PR DESCRIPTION
### Motivation
- Remove redundant `Typed*` prefixes and provide a unified, neutral public API surface for extractors and selectors. 
- Preserve the existing zero-erasure, monomorphized design while eliminating cargo‑cult wrapper names that add cognitive overhead. 

### Description
- Renamed the concrete extractor type `TypedEntityExtractor<S,E>` to `EntityCollectionExtractor<S,E>` and updated its impl, Debug name, and all call sites and re-exports. 
- Replaced the typed value selector APIs with neutral names: `TypedValueSelector -> ValueSelector`, `StaticTypedValueSelector -> StaticValueSelector`, and `FromSolutionTypedValueSelector -> FromSolutionValueSelector`, and updated implementations and tests accordingly. 
- Renamed selector modules/files to neutral names: `typed_move_selector.rs -> move_selector.rs` and `typed_value.rs -> value_selector.rs`, and updated all imports/uses throughout the solver crate. 
- Updated the derive macro emission to use `EntityCollectionExtractor` and synced the `__internal` facade re-exports and WIREFRAME.md files across `core`, `macros`, `scoring`, `solver`, and the top-level facade to reflect the new public surface. 

### Testing
- Ran `cargo fmt` to normalize formatting and `make build` to compile the full workspace; the build completed successfully. 
- Ran the full test suite via `make test` (workspace-level); all unit and doc tests completed successfully and returned green. 
- Updated and exercised selector/extractor unit tests that reference the renamed types; those tests passed as part of the full test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc0d7a18d0833192c92f9b16352653)