### PR TITLE
Use emerald truecolor for ASCII banners in Makefile and console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 # ============== Colors & Symbols ==============
 GREEN := \033[92m
+EMERALD := \033[38;2;16;185;129m
 CYAN := \033[96m
 YELLOW := \033[93m
 MAGENTA := \033[95m
@@ -30,13 +31,13 @@ RUST_VERSION := 1.80+
 
 # ============== Banner ==============
 banner:
-	@printf "$(CYAN)$(BOLD)  ____        _                _____\n"
+	@printf "$(EMERALD)$(BOLD)  ____        _                _____\n"
 	@printf " / ___|  ___ | |_   _____ _ __|  ___|__  _ __ __ _  ___\n"
 	@printf " \\___ \\\\ / _ \\\\| \\\\ \\\\ / / _ \\\\ '__| |_ / _ \\\\| '__/ _\` |/ _ \\\\\n"
 	@printf "  ___) | (_) | |\\\\ V /  __/ |  |  _| (_) | | | (_| |  __/\n"
 	@printf " |____/ \\\\___/|_| \\_/ \\___|_|  |_|  \\___/|_|  \\__, |\\___|\n"
 	@printf "                                             |___/$(RESET)\n"
-	@printf "  $(GRAY)v$(VERSION)$(RESET) $(CYAN)SolverForge Build System$(RESET)\n\n"
+	@printf "  $(GRAY)v$(VERSION)$(RESET) $(EMERALD)SolverForge Build System$(RESET)\n\n"
 
 # ============== Build Targets ==============
 

--- a/crates/solverforge-console/src/banner.rs
+++ b/crates/solverforge-console/src/banner.rs
@@ -5,6 +5,7 @@ use std::io::{self, Write};
 
 // Package version for banner display.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const EMERALD: (u8, u8, u8) = (16, 185, 129);
 
 pub(crate) fn print_banner() {
     let banner = r#"
@@ -22,7 +23,25 @@ pub(crate) fn print_banner() {
     );
 
     let mut stdout = io::stdout().lock();
-    let _ = writeln!(stdout, "{}", banner.bright_cyan());
-    let _ = writeln!(stdout, "{}", version_line.bright_white().bold());
+    let _ = writeln!(
+        stdout,
+        "{}",
+        banner.truecolor(
+            EMERALD.0,
+            EMERALD.1,
+            EMERALD.2
+        )
+    );
+    let _ = writeln!(
+        stdout,
+        "{}",
+        version_line
+            .truecolor(
+                EMERALD.0,
+                EMERALD.1,
+                EMERALD.2
+            )
+            .bold()
+    );
     let _ = stdout.flush();
 }

--- a/crates/solverforge-console/src/banner.rs
+++ b/crates/solverforge-console/src/banner.rs
@@ -26,21 +26,13 @@ pub(crate) fn print_banner() {
     let _ = writeln!(
         stdout,
         "{}",
-        banner.truecolor(
-            EMERALD.0,
-            EMERALD.1,
-            EMERALD.2
-        )
+        banner.truecolor(EMERALD.0, EMERALD.1, EMERALD.2)
     );
     let _ = writeln!(
         stdout,
         "{}",
         version_line
-            .truecolor(
-                EMERALD.0,
-                EMERALD.1,
-                EMERALD.2
-            )
+            .truecolor(EMERALD.0, EMERALD.1, EMERALD.2)
             .bold()
     );
     let _ = stdout.flush();


### PR DESCRIPTION
### Motivation
- Improve the visual appearance of the project banners by switching to an emerald truecolor across the build `Makefile` and the console banner.

### Description
- Add an `EMERALD` ANSI color escape sequence to the `Makefile` and use it for the ASCII banner and the build system label.
- Define an `EMERALD` RGB tuple in `crates/solverforge-console/src/banner.rs` and apply `truecolor(...)` to the banner and version line, with the version made bold.
- Keep existing color constants and banner formatting otherwise unchanged.

### Testing
- Ran `cargo build --workspace` which completed successfully.
- Ran `cargo test --workspace` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdabbb9c88331961bb83fe41deef4)