### PR TITLE
Fix Clippy CI warnings for 0.8.7 solver route builders

### DIFF
--- a/crates/solverforge-solver/src/heuristic/move/list_ruin.rs
+++ b/crates/solverforge-solver/src/heuristic/move/list_ruin.rs
@@ -310,7 +310,7 @@ where
             Actually: after k insertions at positions orig_indices[0..k] (all <= orig_indices[k]
             since sorted), orig_indices[k]'s effective position has shifted by k.
             */
-            for (&idx, val) in orig_indices.iter().zip(vals.into_iter()) {
+            for (&idx, val) in orig_indices.iter().zip(vals) {
                 list_insert(s, orig_entity, idx, val);
             }
         }));

--- a/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright.rs
@@ -387,10 +387,7 @@ where
 
             {
                 let sd = step_scope.score_director_mut();
-                for (entity_idx, index_route) in available_entity_slots
-                    .into_iter()
-                    .zip(non_empty)
-                {
+                for (entity_idx, index_route) in available_entity_slots.into_iter().zip(non_empty) {
                     sd.before_variable_changed(descriptor_index, entity_idx);
                     let element_route: Vec<E> = index_route
                         .iter()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright.rs
@@ -280,7 +280,7 @@ where
                 }
             }
         }
-        savings.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+        savings.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.0));
 
         // Greedy merge
         for (merge_idx, (_, i, j)) in savings.iter().enumerate() {
@@ -337,7 +337,7 @@ where
                 }
                 let candidate_route: Vec<usize> = test_ri
                     .into_iter()
-                    .chain(test_rj.into_iter())
+                    .chain(test_rj)
                     .map(|idx| index_to_element(solution, idx).into())
                     .collect();
                 if !feasible(solution, &candidate_route) {
@@ -389,7 +389,7 @@ where
                 let sd = step_scope.score_director_mut();
                 for (entity_idx, index_route) in available_entity_slots
                     .into_iter()
-                    .zip(non_empty.into_iter())
+                    .zip(non_empty)
                 {
                     sd.before_variable_changed(descriptor_index, entity_idx);
                     let element_route: Vec<E> = index_route


### PR DESCRIPTION
### Motivation
- Remove Clippy lints reported on CI for the `0.8.7` solver crates by making small iterator and sort adjustments while preserving existing behavior.

### Description
- Removed unnecessary `.into_iter()` conversions in the list ruin reinsertion path (`crates/solverforge-solver/src/heuristic/move/list_ruin.rs`) and in Clarke–Wright route construction chaining/assignment paths (`crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright.rs`).
- Replaced `savings.sort_unstable_by(|a, b| b.0.cmp(&a.0))` with `savings.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.0))` to satisfy the `unnecessary_sort_by` lint while keeping the same ordering.

### Testing
- Ran `cargo clippy --workspace --all-targets --all-features`, which completed successfully with the Clippy warnings resolved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2772ad700833199f877d2854c12ba)