### PR TITLE
return Sc::zero() for unchanged

### DIFF
--- a/crates/solverforge-scoring/src/constraint/cross_bi_incremental.rs
+++ b/crates/solverforge-scoring/src/constraint/cross_bi_incremental.rs
@@ -576,6 +576,11 @@ where
         let b_changed = self
             .b_source
             .assert_localizes(descriptor_index, &self.constraint_ref.name);
+
+        if !a_changed && !b_changed {
+            return Sc::zero();
+        }
+
         let entities_a = self.extractor_a.extract(solution);
         let entities_b = self.extractor_b.extract(solution);
         let mut total = Sc::zero();
@@ -595,6 +600,11 @@ where
         let b_changed = self
             .b_source
             .assert_localizes(descriptor_index, &self.constraint_ref.name);
+
+        if !a_changed && !b_changed {
+            return Sc::zero();
+        }
+
         let mut total = Sc::zero();
         if a_changed {
             total = total + self.retract_a(entity_index);


### PR DESCRIPTION
Hello @blackopsrepl :smiley: 
I was looking into the scoring side today and found a place where an early return seemed useful. 

1. Changes
Add an early return in `IncrementalCrossBiConstraint::on_insert` when the changed descriptor does not affect either a and b. This avoids calling `extractor_a.extract(solution)` and `extractor_b.extract(solution)` for unrelated descriptor changes.

2. Expected Impact
Reduces unnecessary work in the incremental scoring hot path during local search candidate evaluation. This should help multi-descriptor problems with multiple constraints, where many entity changes may be irrelevant to a given cross-bi constraint.
