### PR TITLE
refactor(config): centralize repeated move selector default literals

### DIFF
--- a/crates/solverforge-config/src/move_selector.rs
+++ b/crates/solverforge-config/src/move_selector.rs
@@ -110,10 +110,11 @@ pub struct NearbyChangeMoveConfig {
 
 impl Default for NearbyChangeMoveConfig {
     fn default() -> Self {
+        let (max_nearby, target) = default_nearby_target_config();
         Self {
-            max_nearby: 10,
+            max_nearby,
             value_candidate_limit: None,
-            target: VariableTargetConfig::default(),
+            target,
         }
     }
 }
@@ -129,10 +130,8 @@ pub struct NearbySwapMoveConfig {
 
 impl Default for NearbySwapMoveConfig {
     fn default() -> Self {
-        Self {
-            max_nearby: 10,
-            target: VariableTargetConfig::default(),
-        }
+        let (max_nearby, target) = default_nearby_target_config();
+        Self { max_nearby, target }
     }
 }
 
@@ -232,10 +231,8 @@ pub struct NearbyListChangeMoveConfig {
 
 impl Default for NearbyListChangeMoveConfig {
     fn default() -> Self {
-        Self {
-            max_nearby: 10,
-            target: VariableTargetConfig::default(),
-        }
+        let (max_nearby, target) = default_nearby_target_config();
+        Self { max_nearby, target }
     }
 }
 
@@ -259,10 +256,8 @@ pub struct NearbyListSwapMoveConfig {
 
 impl Default for NearbyListSwapMoveConfig {
     fn default() -> Self {
-        Self {
-            max_nearby: 10,
-            target: VariableTargetConfig::default(),
-        }
+        let (max_nearby, target) = default_nearby_target_config();
+        Self { max_nearby, target }
     }
 }
 
@@ -280,10 +275,11 @@ pub struct SublistChangeMoveConfig {
 
 impl Default for SublistChangeMoveConfig {
     fn default() -> Self {
+        let (min_sublist_size, max_sublist_size, target) = default_sublist_target_config();
         Self {
-            min_sublist_size: 1,
-            max_sublist_size: 3,
-            target: VariableTargetConfig::default(),
+            min_sublist_size,
+            max_sublist_size,
+            target,
         }
     }
 }
@@ -302,10 +298,11 @@ pub struct SublistSwapMoveConfig {
 
 impl Default for SublistSwapMoveConfig {
     fn default() -> Self {
+        let (min_sublist_size, max_sublist_size, target) = default_sublist_target_config();
         Self {
-            min_sublist_size: 1,
-            max_sublist_size: 3,
-            target: VariableTargetConfig::default(),
+            min_sublist_size,
+            max_sublist_size,
+            target,
         }
     }
 }
@@ -473,4 +470,12 @@ fn default_conflict_repair_max_moves() -> usize {
 
 fn default_require_hard_improvement() -> bool {
     true
+}
+
+fn default_nearby_target_config() -> (usize, VariableTargetConfig) {
+    (10, VariableTargetConfig::default())
+}
+
+fn default_sublist_target_config() -> (usize, usize, VariableTargetConfig) {
+    (1, 3, VariableTargetConfig::default())
 }


### PR DESCRIPTION
### Motivation
- Reduce repeated literal/initializer drift in `move_selector.rs` by centralizing the default `(max_nearby, target)` and `(min_sublist_size, max_sublist_size, target)` tuples so defaults are maintained in one place while preserving behavior and public surface.

### Description
- Introduces `default_nearby_target_config()` and `default_sublist_target_config()` and updates `Default` impls for nearby/sublist move-selector configs in `crates/solverforge-config/src/move_selector.rs` to consume those helpers, removing repeated literal initializers and keeping no public API or erasure changes (net diff: +25 / -20, net +5 lines).

### Testing
- Ran `cargo fmt` and `cargo test -p solverforge-config`, and all crate unit tests passed (`22` unit tests) and the doc-test for `solverforge_config` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032111207883318b0c852eeb7bb0b2)