### PR TITLE
Fix filtered flattened keyed join targets

### DIFF
--- a/crates/solverforge-scoring/src/constraint/flattened_bi/incremental.rs
+++ b/crates/solverforge-scoring/src/constraint/flattened_bi/incremental.rs
@@ -36,6 +36,9 @@ where
         // Build temporary index for standalone evaluation
         let mut temp_index: HashMap<(K, CK), Vec<(usize, C)>> = HashMap::new();
         for (b_idx, b) in entities_b.iter().enumerate() {
+            if !self.extractor_b.contains(solution, b) {
+                continue;
+            }
             let join_key = (self.key_b)(b);
             for c in (self.flatten)(b) {
                 let c_key = (self.c_key_fn)(c);
@@ -47,6 +50,9 @@ where
         }
 
         for (a_idx, a) in entities_a.iter().enumerate() {
+            if !self.extractor_a.contains(solution, a) {
+                continue;
+            }
             let join_key = (self.key_a)(a);
             let lookup_key = (self.a_lookup_fn)(a);
 
@@ -70,6 +76,9 @@ where
         // Build temporary index
         let mut temp_index: HashMap<(K, CK), Vec<(usize, C)>> = HashMap::new();
         for (b_idx, b) in entities_b.iter().enumerate() {
+            if !self.extractor_b.contains(solution, b) {
+                continue;
+            }
             let join_key = (self.key_b)(b);
             for c in (self.flatten)(b) {
                 let c_key = (self.c_key_fn)(c);
@@ -81,6 +90,9 @@ where
         }
 
         for (a_idx, a) in entities_a.iter().enumerate() {
+            if !self.extractor_a.contains(solution, a) {
+                continue;
+            }
             let join_key = (self.key_a)(a);
             let lookup_key = (self.a_lookup_fn)(a);
 
@@ -103,7 +115,7 @@ where
         let entities_b = self.extractor_b.extract(solution);
 
         // Build C index once: O(B × C)
-        self.build_c_index(entities_b);
+        self.build_c_index(solution, entities_b);
 
         // Insert all A entities: O(A) with O(1) lookups each
         let mut total = Sc::zero();

--- a/crates/solverforge-scoring/src/constraint/flattened_bi/state.rs
+++ b/crates/solverforge-scoring/src/constraint/flattened_bi/state.rs
@@ -233,11 +233,14 @@ where
     }
 
     // Build C index: (join_key, c_key) → list of (b_idx, c_value)
-    pub(super) fn build_c_index(&mut self, entities_b: &[B]) {
+    pub(super) fn build_c_index(&mut self, solution: &S, entities_b: &[B]) {
         self.bucket_by_key.clear();
         self.c_index.clear();
         self.b_entries.clear();
         for (b_idx, b) in entities_b.iter().enumerate() {
+            if !self.extractor_b.contains(solution, b) {
+                continue;
+            }
             let join_key = (self.key_b)(b);
             let mut entries = Vec::new();
             for c in (self.flatten)(b) {
@@ -326,6 +329,9 @@ where
         }
 
         let a = &entities_a[a_idx];
+        if !self.extractor_a.contains(solution, a) {
+            return Sc::zero();
+        }
         let bucket = self.bucket_for_key((self.key_a)(a), (self.a_lookup_fn)(a));
         let indices = self.a_by_bucket.entry(bucket).or_default();
         let pos = indices.len();
@@ -391,6 +397,9 @@ where
             return Sc::zero();
         }
         let b = &entities_b[b_idx];
+        if !self.extractor_b.contains(solution, b) {
+            return Sc::zero();
+        }
         let join_key = (self.key_b)(b);
         let mut entries = Vec::new();
         let mut total = Sc::zero();

--- a/crates/solverforge-scoring/src/constraint/tests/flattened_bi.rs
+++ b/crates/solverforge-scoring/src/constraint/tests/flattened_bi.rs
@@ -3,6 +3,7 @@
 use crate::api::constraint_set::IncrementalConstraint;
 use crate::constraint::flattened_bi::FlattenedBiConstraint;
 use crate::stream::collection_extract::{source, ChangeSource, SourceExtract};
+use crate::stream::{joiner, ConstraintFactory};
 use solverforge_core::score::SoftScore;
 use solverforge_core::{ConstraintRef, ImpactType};
 
@@ -234,4 +235,68 @@ fn test_unassigned_shift() {
 
     // Unassigned shift doesn't match
     assert_eq!(constraint.evaluate(&schedule), SoftScore::of(0));
+}
+
+#[test]
+fn flattened_keyed_join_honors_filtered_target_stream() {
+    let mut constraint = ConstraintFactory::<Schedule, SoftScore>::new()
+        .for_each(source(
+            (|s: &Schedule| s.shifts.as_slice()) as fn(&Schedule) -> &[Shift],
+            ChangeSource::Descriptor(0),
+        ))
+        .join((
+            ConstraintFactory::<Schedule, SoftScore>::new()
+                .for_each(source(
+                    (|s: &Schedule| s.employees.as_slice()) as fn(&Schedule) -> &[Employee],
+                    ChangeSource::Descriptor(1),
+                ))
+                .filter(|employee: &Employee| employee.id == 1),
+            joiner::equal_bi(
+                |shift: &Shift| shift.employee_id,
+                |employee: &Employee| Some(employee.id),
+            ),
+        ))
+        .flatten_last(
+            |employee: &Employee| employee.unavailable_days.as_slice(),
+            |day: &u32| *day,
+            |shift: &Shift| shift.day,
+        )
+        .penalize(SoftScore::of(1))
+        .named("filtered target flattened join");
+
+    let mut schedule = Schedule {
+        shifts: vec![
+            Shift {
+                employee_id: Some(0),
+                day: 5,
+            },
+            Shift {
+                employee_id: Some(1),
+                day: 5,
+            },
+        ],
+        employees: vec![
+            Employee {
+                id: 0,
+                unavailable_days: vec![5],
+            },
+            Employee {
+                id: 1,
+                unavailable_days: vec![5],
+            },
+        ],
+    };
+
+    assert_eq!(constraint.match_count(&schedule), 1);
+    assert_eq!(constraint.evaluate(&schedule), SoftScore::of(-1));
+
+    let mut total = constraint.initialize(&schedule);
+    assert_eq!(total, SoftScore::of(-1));
+
+    total = total + constraint.on_retract(&schedule, 1, 1);
+    schedule.employees[1].id = 2;
+    total = total + constraint.on_insert(&schedule, 1, 1);
+
+    assert_eq!(total, SoftScore::of(0));
+    assert_eq!(total, constraint.evaluate(&schedule));
 }


### PR DESCRIPTION
## Summary
- honor `CollectionExtract::contains` when flattened-bi constraints build/evaluate right-hand flattened indexes
- skip filtered-out left rows during evaluate, match counting, and incremental initialization
- add a regression for `.join((filtered_stream, equal_bi(...))).flatten_last(...)` covering evaluate, `match_count`, initialize, and B-side localized updates

Addresses the Codex review thread on #64: https://github.com/SolverForge/solverforge/pull/64#discussion_r3249858082

## Validation
- `cargo fmt --check`
- `cargo test -p solverforge-scoring flattened_keyed_join_honors_filtered_target_stream`
- `cargo test -p solverforge-scoring flattened`
- `cargo test -p solverforge-scoring filtered`
- `cargo test -p solverforge-scoring`
- `cargo clippy -p solverforge-scoring --all-targets --all-features -- -D warnings`