### PR TITLE
fix(solver): preserve controlled required construction

### DIFF
--- a/crates/solverforge-solver/WIREFRAME.md
+++ b/crates/solverforge-solver/WIREFRAME.md
@@ -512,7 +512,10 @@ entity/value/child order without boxing cursors or erasing selector types.
 `MoveCursor::selector_index()` reports the stable child index for telemetry
 through union selectors. Cursor implementations store only discovered
 candidates, and broad scalar/list selectors generate the next candidate from
-cursor-native loop state instead of prebuilding full move vectors. The cursor
+cursor-native loop state instead of prebuilding full move vectors.
+`next_candidate_with_control()` lets expensive cursors poll solve control during
+generation; because `None` can mean either interruption or exhaustion, callers
+recheck the same control signal before resolving an exhausted scan. The cursor
 contract also provides `release_candidate()`, `apply_owned_candidate()`,
 `next_owned_candidate()`, `next_owned_candidate_matching()`, and
 `next_owned_candidate_inspected()` so phases can end candidate residency
@@ -757,7 +760,7 @@ union variants and keep speculative rollback statically typed.
 
 **`MoveArena<M>`** — Reusable-capacity arena. `new()`, `with_capacity()`, `push()`, `get()`, `iter()`, `iter_mut()`, `take(index)`, `reset()`, `extend()`, `shuffle()`, `len()`, `is_empty()`, and `capacity()`. `take()` transfers exactly one selected slot per reset cycle; `reset()` drops the remaining live slots while retaining allocated capacity and panics are used to reject double-take.
 
-**`MoveCursor<S, M>`** — cursor contract with `next_candidate()`, `candidate(id)`, `take_candidate(id)`, `release_candidate(id)`, `apply_owned_candidate(id)`, `next_owned_candidate()`, `next_owned_candidate_matching()`, `next_owned_candidate_inspected()`, and optional `selector_index(id)`. Consumers may stop after any candidate; dropping a cursor releases retained candidates and unconsumed source state without exhausting the tail. Implementations must not require full enumeration for cleanup or callbacks.
+**`MoveCursor<S, M>`** — cursor contract with `next_candidate()`, `next_candidate_with_control(should_stop)`, `candidate(id)`, `take_candidate(id)`, `release_candidate(id)`, `apply_owned_candidate(id)`, `next_owned_candidate()`, `next_owned_candidate_matching()`, `next_owned_candidate_inspected()`, and optional `selector_index(id)`. Consumers may stop after any candidate; dropping a cursor releases retained candidates and unconsumed source state without exhausting the tail. Implementations must not require full enumeration for cleanup or callbacks.
 
 **`MoveCandidateRef<'a, S, M>`** — borrowable move view: either `Borrowed(&M)` or `Sequential(SequentialCompositeMoveRef<'a, S, M>)`.
 

--- a/crates/solverforge-solver/src/builder/selector/grouped_scalar.rs
+++ b/crates/solverforge-solver/src/builder/selector/grouped_scalar.rs
@@ -189,6 +189,19 @@ where
     S: PlanningSolution + 'static,
 {
     fn next_candidate(&mut self) -> Option<CandidateId> {
+        self.next_candidate_with_control(&mut || false)
+    }
+
+    fn next_candidate_with_control<ShouldStop>(
+        &mut self,
+        should_stop: &mut ShouldStop,
+    ) -> Option<CandidateId>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if should_stop() {
+            return None;
+        }
         self.activate();
         if self.next_index < self.store.len() {
             let id = CandidateId::new(self.next_index);
@@ -197,7 +210,7 @@ where
         }
         let assignment_cursor = self.assignment_cursor.as_mut()?;
         let mov = assignment_cursor
-            .next_move()?
+            .next_move_with_control(should_stop)?
             .with_require_hard_improvement(self.require_hard_improvement);
         let id = self.store.push(ScalarMoveUnion::CompoundScalar(mov));
         self.next_index = id.index() + 1;

--- a/crates/solverforge-solver/src/heuristic/selector/move_selector/borrowed.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/move_selector/borrowed.rs
@@ -224,6 +224,22 @@ where
 pub trait MoveCursor<S: PlanningSolution, M: Move<S>> {
     fn next_candidate(&mut self) -> Option<CandidateId>;
 
+    /// Pulls the next candidate while allowing expensive cursor implementations
+    /// to observe solve control between units of generation work.
+    fn next_candidate_with_control<ShouldStop>(
+        &mut self,
+        should_stop: &mut ShouldStop,
+    ) -> Option<CandidateId>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if should_stop() {
+            None
+        } else {
+            self.next_candidate()
+        }
+    }
+
     fn candidate(&self, id: CandidateId) -> Option<MoveCandidateRef<'_, S, M>>;
 
     fn take_candidate(&mut self, id: CandidateId) -> M;

--- a/crates/solverforge-solver/src/heuristic/selector/move_selector/borrowed.rs
+++ b/crates/solverforge-solver/src/heuristic/selector/move_selector/borrowed.rs
@@ -225,7 +225,9 @@ pub trait MoveCursor<S: PlanningSolution, M: Move<S>> {
     fn next_candidate(&mut self) -> Option<CandidateId>;
 
     /// Pulls the next candidate while allowing expensive cursor implementations
-    /// to observe solve control between units of generation work.
+    /// to observe solve control between units of generation work. A `None`
+    /// result may mean either exhaustion or requested interruption, so callers
+    /// must recheck the same control signal before resolving an exhausted scan.
     fn next_candidate_with_control<ShouldStop>(
         &mut self,
         should_stop: &mut ShouldStop,

--- a/crates/solverforge-solver/src/phase/construction/forager_step.rs
+++ b/crates/solverforge-solver/src/phase/construction/forager_step.rs
@@ -14,7 +14,8 @@ use super::{ConstructionChoice, Placement, StrongestFitForager, WeakestFitForage
 use crate::heuristic::r#move::Move;
 use crate::heuristic::selector::move_selector::{CandidateId, MoveCursor};
 use crate::phase::control::{
-    settle_construction_interrupt, should_interrupt_before_evaluation, StepInterrupt,
+    settle_construction_interrupt, should_interrupt_before_candidate,
+    should_interrupt_before_evaluation, StepInterrupt,
 };
 use crate::scope::{ProgressCallback, StepScope};
 use crate::stats::{
@@ -32,7 +33,9 @@ where
     M: Move<S>,
     C: MoveCursor<S, M>,
 {
-    let candidate_id = placement.candidates_mut().next_candidate()?;
+    let candidate_id = placement
+        .candidates_mut()
+        .next_candidate_with_control(&mut || should_interrupt_before_candidate(step_scope))?;
     let construction_target = CandidateTraceConstructionTarget {
         descriptor_index: placement.entity_ref.descriptor_index,
         entity_index: placement.entity_ref.entity_index,

--- a/crates/solverforge-solver/src/phase/construction/forager_step.rs
+++ b/crates/solverforge-solver/src/phase/construction/forager_step.rs
@@ -95,6 +95,27 @@ fn release<S, D, BestCb, M, C>(
     assert!(placement.candidates_mut().release_candidate(candidate_id));
 }
 
+fn mark_retained_ignored<S, D, BestCb, M, C>(
+    placement: &Placement<S, M, C>,
+    retained: Option<CandidateId>,
+    step_scope: &mut StepScope<'_, '_, '_, S, D, BestCb>,
+) where
+    S: PlanningSolution,
+    D: Director<S>,
+    BestCb: ProgressCallback<S>,
+    M: Move<S>,
+    C: MoveCursor<S, M>,
+{
+    if let Some(candidate_id) = retained {
+        mark_candidate_disposition(
+            placement,
+            candidate_id,
+            CandidateTraceDisposition::ForagerIgnored,
+            step_scope,
+        );
+    }
+}
+
 fn evaluation_should_terminate<S, D, BestCb>(
     step_scope: &mut StepScope<'_, '_, '_, S, D, BestCb>,
 ) -> bool
@@ -134,6 +155,9 @@ where
             return None;
         }
         let Some(candidate_id) = next_candidate(placement, step_scope) else {
+            if should_interrupt_before_candidate(step_scope) {
+                return None;
+            }
             break;
         };
         let evaluation_started = Instant::now();
@@ -214,17 +238,22 @@ where
     let mut retained: Option<(CandidateId, S::Score)> = None;
     loop {
         if evaluation_should_terminate(step_scope) {
-            if let Some((candidate_id, _)) = retained {
-                mark_candidate_disposition(
-                    placement,
-                    candidate_id,
-                    CandidateTraceDisposition::ForagerIgnored,
-                    step_scope,
-                );
-            }
+            mark_retained_ignored(
+                placement,
+                retained.map(|(candidate_id, _)| candidate_id),
+                step_scope,
+            );
             return None;
         }
         let Some(candidate_id) = next_candidate(placement, step_scope) else {
+            if should_interrupt_before_candidate(step_scope) {
+                mark_retained_ignored(
+                    placement,
+                    retained.map(|(candidate_id, _)| candidate_id),
+                    step_scope,
+                );
+                return None;
+            }
             break;
         };
         let evaluation_started = Instant::now();
@@ -319,17 +348,22 @@ where
     let mut retained: Option<(CandidateId, S::Score)> = None;
     loop {
         if evaluation_should_terminate(step_scope) {
-            if let Some((candidate_id, _)) = retained {
-                mark_candidate_disposition(
-                    placement,
-                    candidate_id,
-                    CandidateTraceDisposition::ForagerIgnored,
-                    step_scope,
-                );
-            }
+            mark_retained_ignored(
+                placement,
+                retained.map(|(candidate_id, _)| candidate_id),
+                step_scope,
+            );
             return None;
         }
         let Some(candidate_id) = next_candidate(placement, step_scope) else {
+            if should_interrupt_before_candidate(step_scope) {
+                mark_retained_ignored(
+                    placement,
+                    retained.map(|(candidate_id, _)| candidate_id),
+                    step_scope,
+                );
+                return None;
+            }
             break;
         };
         let evaluation_started = Instant::now();
@@ -444,17 +478,22 @@ where
     let mut retained: Option<(CandidateId, i64)> = None;
     loop {
         if evaluation_should_terminate(step_scope) {
-            if let Some((candidate_id, _)) = retained {
-                mark_candidate_disposition(
-                    placement,
-                    candidate_id,
-                    CandidateTraceDisposition::ForagerIgnored,
-                    step_scope,
-                );
-            }
+            mark_retained_ignored(
+                placement,
+                retained.map(|(candidate_id, _)| candidate_id),
+                step_scope,
+            );
             return None;
         }
         let Some(candidate_id) = next_candidate(placement, step_scope) else {
+            if should_interrupt_before_candidate(step_scope) {
+                mark_retained_ignored(
+                    placement,
+                    retained.map(|(candidate_id, _)| candidate_id),
+                    step_scope,
+                );
+                return None;
+            }
             break;
         };
         let evaluation_started = Instant::now();

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_entity.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_entity.rs
@@ -11,6 +11,7 @@ use super::assignment_path::{
 use super::assignment_state::{CapacityConflict, ScalarAssignmentState};
 use crate::builder::ScalarAssignmentBinding;
 use crate::heuristic::r#move::CompoundScalarMove;
+use crate::phase::control::GENERATION_POLL_INTERVAL;
 
 pub(super) struct EntityValueCursor {
     pub(super) entities: Vec<usize>,
@@ -373,53 +374,78 @@ pub(super) fn assigned_entities_by_position<S>(
     entities
 }
 
-pub(super) fn required_entities_by_scarcity<S>(
+pub(super) fn required_entities_by_scarcity<S, ShouldStop>(
     group: &ScalarAssignmentBinding<S>,
     solution: &S,
     state: &ScalarAssignmentState,
     value_candidate_limit: Option<usize>,
-) -> Vec<usize>
+    should_stop: &mut ShouldStop,
+) -> Option<Vec<usize>>
 where
     S: PlanningSolution,
+    ShouldStop: FnMut() -> bool,
 {
-    let mut entities = (0..group.entity_count(solution))
-        .filter(|entity_index| {
-            state.is_required(*entity_index) && state.current_value(*entity_index).is_none()
-        })
-        .map(|entity_index| {
-            let candidate_count = group
-                .candidate_values(solution, entity_index, value_candidate_limit)
-                .len();
-            (
-                candidate_count,
-                group.entity_order_key(solution, entity_index),
-                entity_index,
-            )
-        })
-        .collect::<Vec<_>>();
+    let mut entities = Vec::new();
+    for entity_index in 0..group.entity_count(solution) {
+        if should_stop() {
+            return None;
+        }
+        if !state.is_required(entity_index) || state.current_value(entity_index).is_some() {
+            continue;
+        }
+        let candidate_count = group
+            .candidate_values(solution, entity_index, value_candidate_limit)
+            .len();
+        if should_stop() {
+            return None;
+        }
+        entities.push((
+            candidate_count,
+            group.entity_order_key(solution, entity_index),
+            entity_index,
+        ));
+    }
     entities.sort_unstable();
-    entities
-        .into_iter()
-        .map(|(_, _, entity_index)| entity_index)
-        .collect()
+    if should_stop() {
+        return None;
+    }
+    Some(
+        entities
+            .into_iter()
+            .map(|(_, _, entity_index)| entity_index)
+            .collect(),
+    )
 }
 
-pub(super) fn required_value_degrees<S>(
+pub(super) fn required_value_degrees<S, ShouldStop>(
     group: &ScalarAssignmentBinding<S>,
     solution: &S,
     entities: &[usize],
     value_candidate_limit: Option<usize>,
-) -> HashMap<usize, usize>
+    should_stop: &mut ShouldStop,
+) -> Option<HashMap<usize, usize>>
 where
     S: PlanningSolution,
+    ShouldStop: FnMut() -> bool,
 {
     let mut degrees = HashMap::new();
+    let mut processed_edges = 0usize;
     for entity_index in entities {
+        if should_stop() {
+            return None;
+        }
         for value in group.candidate_values(solution, *entity_index, value_candidate_limit) {
             *degrees.entry(value).or_insert(0) += 1;
+            processed_edges += 1;
+            if processed_edges.is_multiple_of(GENERATION_POLL_INTERVAL) && should_stop() {
+                return None;
+            }
         }
     }
-    degrees
+    if should_stop() {
+        return None;
+    }
+    Some(degrees)
 }
 
 pub(super) fn sort_values_by_required_scarcity<S>(

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_entity.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_entity.rs
@@ -5,7 +5,9 @@ use solverforge_core::domain::PlanningSolution;
 use super::assignment_candidate::{
     order_candidates, ordered_entities, AssignmentMoveIntent, ScalarAssignmentMoveOptions,
 };
-use super::assignment_path::{assignment_move_for_entity_value, move_from_edits};
+use super::assignment_path::{
+    assignment_move_for_entity_value, move_from_edits, AssignmentRequest,
+};
 use super::assignment_state::{CapacityConflict, ScalarAssignmentState};
 use crate::builder::ScalarAssignmentBinding;
 use crate::heuristic::r#move::CompoundScalarMove;
@@ -21,17 +23,22 @@ pub(super) struct EntityValueCursor {
 }
 
 impl EntityValueCursor {
-    pub(super) fn next<S>(
+    pub(super) fn next<S, ShouldStop>(
         &mut self,
         group: &ScalarAssignmentBinding<S>,
         solution: &S,
         state: &mut ScalarAssignmentState,
+        should_stop: &mut ShouldStop,
     ) -> Option<CompoundScalarMove<S>>
     where
         S: PlanningSolution,
+        ShouldStop: FnMut() -> bool,
     {
         let intent = self.kind.intent();
         while self.entity_pos < self.entities.len() {
+            if should_stop() {
+                return None;
+            }
             let entity_index = self.entities[self.entity_pos];
             if self.kind == AssignmentMoveKind::Required
                 && state.current_value(entity_index).is_some()
@@ -69,16 +76,20 @@ impl EntityValueCursor {
             }
             while self.value_pos < self.values.len() {
                 let value = self.values[self.value_pos];
-                self.value_pos += 1;
-                if let Some(mov) = assignment_move_for_entity_value(
+                let candidate = assignment_move_for_entity_value(
                     group,
                     solution,
                     state,
-                    entity_index,
-                    value,
+                    AssignmentRequest::root(entity_index, value, self.options.max_depth),
                     self.options,
                     intent,
-                ) {
+                    should_stop,
+                );
+                if should_stop() {
+                    return None;
+                }
+                self.value_pos += 1;
+                if let Some(mov) = candidate {
                     return Some(mov);
                 }
             }
@@ -135,19 +146,27 @@ impl CapacityCursor {
         }
     }
 
-    pub(super) fn next<S>(
+    pub(super) fn next<S, ShouldStop>(
         &mut self,
         group: &ScalarAssignmentBinding<S>,
         solution: &S,
         state: &mut ScalarAssignmentState,
+        should_stop: &mut ShouldStop,
     ) -> Option<CompoundScalarMove<S>>
     where
         S: PlanningSolution,
+        ShouldStop: FnMut() -> bool,
     {
         loop {
+            if should_stop() {
+                return None;
+            }
             if let Some(cursor) = &mut self.repair_cursor {
-                if let Some(mov) = cursor.next(group, solution, state) {
+                if let Some(mov) = cursor.next(group, solution, state, should_stop) {
                     return Some(mov);
+                }
+                if should_stop() {
+                    return None;
                 }
                 self.repair_cursor = None;
             }

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_family.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_family.rs
@@ -34,29 +34,46 @@ pub(super) enum AssignmentFamilyCursor {
 }
 
 impl AssignmentFamilyCursor {
-    pub(super) fn required_entity_values<S>(
+    pub(super) fn required_entity_values<S, ShouldStop>(
         group: &ScalarAssignmentBinding<S>,
         solution: &S,
         state: &ScalarAssignmentState,
         options: ScalarAssignmentMoveOptions,
-    ) -> Self
+        should_stop: &mut ShouldStop,
+    ) -> Option<Self>
     where
         S: PlanningSolution,
+        ShouldStop: FnMut() -> bool,
     {
         let mut entities = if options.required_scarcity_ordering {
-            required_entities_by_scarcity(group, solution, state, options.value_candidate_limit)
+            required_entities_by_scarcity(
+                group,
+                solution,
+                state,
+                options.value_candidate_limit,
+                should_stop,
+            )?
         } else {
             super::assignment_candidate::ordered_entities(group, solution, |entity_index| {
                 state.is_required(entity_index) && state.current_value(entity_index).is_none()
             })
         };
+        if should_stop() {
+            return None;
+        }
         order_candidates(&mut entities, options, 0xA551_6EED_0000_000B);
         let value_degrees = if options.required_scarcity_ordering {
-            required_value_degrees(group, solution, &entities, options.value_candidate_limit)
+            required_value_degrees(
+                group,
+                solution,
+                &entities,
+                options.value_candidate_limit,
+                should_stop,
+            )?
         } else {
             HashMap::new()
         };
-        Self::EntityValues(EntityValueCursor {
+        Some(Self::EntityValues(EntityValueCursor {
             entities,
             entity_pos: 0,
             values: Vec::new(),
@@ -64,7 +81,7 @@ impl AssignmentFamilyCursor {
             value_degrees,
             options,
             kind: AssignmentMoveKind::Required,
-        })
+        }))
     }
 
     pub(super) fn entity_values(

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_path.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_path.rs
@@ -9,18 +9,24 @@ use crate::builder::ScalarAssignmentBinding;
 use crate::heuristic::r#move::CompoundScalarMove;
 use crate::planning::ScalarEdit;
 
-pub(super) fn assignment_move_for_entity_value<S>(
+pub(super) fn assignment_move_for_entity_value<S, ShouldStop>(
     group: &ScalarAssignmentBinding<S>,
     solution: &S,
     state: &mut ScalarAssignmentState,
-    entity_index: usize,
-    value: usize,
+    assignment: AssignmentRequest,
     options: ScalarAssignmentMoveOptions,
     intent: AssignmentMoveIntent,
+    should_stop: &mut ShouldStop,
 ) -> Option<CompoundScalarMove<S>>
 where
     S: PlanningSolution,
+    ShouldStop: FnMut() -> bool,
 {
+    if should_stop() {
+        return None;
+    }
+    let entity_index = assignment.entity_index;
+    let value = assignment.value;
     if state.current_value(entity_index) == Some(value) {
         return None;
     }
@@ -35,14 +41,11 @@ where
     };
     let produced = search.assign(
         state,
-        AssignmentRequest {
-            entity_index,
-            value,
-            depth: options.max_depth,
-        },
+        assignment,
         &mut visiting,
         &mut changes,
         &mut edits,
+        should_stop,
     );
     let mov = if produced && state.scalar_edits_feasible(group, solution, &edits) {
         move_from_edits(group, solution, &edits, intent.reason)
@@ -54,10 +57,20 @@ where
 }
 
 #[derive(Clone, Copy)]
-struct AssignmentRequest {
+pub(super) struct AssignmentRequest {
     entity_index: usize,
     value: usize,
     depth: usize,
+}
+
+impl AssignmentRequest {
+    pub(super) fn root(entity_index: usize, value: usize, max_depth: usize) -> Self {
+        Self {
+            entity_index,
+            value,
+            depth: max_depth,
+        }
+    }
 }
 
 struct AugmentingPathSearch<'a, S> {
@@ -68,14 +81,21 @@ struct AugmentingPathSearch<'a, S> {
 }
 
 impl<S> AugmentingPathSearch<'_, S> {
-    fn assign(
+    fn assign<ShouldStop>(
         &self,
         state: &mut ScalarAssignmentState,
         assignment: AssignmentRequest,
         visiting: &mut HashSet<usize>,
         changes: &mut Vec<(usize, Option<usize>)>,
         edits: &mut Vec<ScalarEdit<S>>,
-    ) -> bool {
+        should_stop: &mut ShouldStop,
+    ) -> bool
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if should_stop() {
+            return false;
+        }
         let entity_index = assignment.entity_index;
         let value = assignment.value;
         if !self
@@ -134,6 +154,10 @@ impl<S> AugmentingPathSearch<'_, S> {
             self.group
                 .candidate_values(self.solution, blocker, self.value_candidate_limit);
         for alternative in alternatives {
+            if should_stop() {
+                visiting.remove(&entity_index);
+                return false;
+            }
             if state.current_value(blocker) == Some(alternative) {
                 continue;
             }
@@ -149,6 +173,7 @@ impl<S> AugmentingPathSearch<'_, S> {
                 visiting,
                 changes,
                 edits,
+                should_stop,
             ) {
                 let blockers_after_reassignment =
                     state.blockers(self.group, self.solution, entity_index, value);

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_required_batch.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_required_batch.rs
@@ -8,19 +8,23 @@ use super::assignment_candidate::{
 use super::assignment_entity::{
     required_entities_by_scarcity, required_value_degrees, sort_values_by_required_scarcity,
 };
-use super::assignment_path::{assignment_move_for_entity_value, move_from_edits};
+use super::assignment_path::{
+    assignment_move_for_entity_value, move_from_edits, AssignmentRequest,
+};
 use super::assignment_state::ScalarAssignmentState;
 use crate::builder::ScalarAssignmentBinding;
 use crate::heuristic::r#move::CompoundScalarMove;
 
-pub(super) fn required_batch_move<S>(
+pub(super) fn required_batch_move<S, ShouldStop>(
     group: &ScalarAssignmentBinding<S>,
     solution: &S,
     state: &mut ScalarAssignmentState,
     options: ScalarAssignmentMoveOptions,
+    should_stop: &mut ShouldStop,
 ) -> Option<CompoundScalarMove<S>>
 where
     S: PlanningSolution,
+    ShouldStop: FnMut() -> bool,
 {
     let mut entities =
         required_entities_by_scarcity(group, solution, state, options.value_candidate_limit);
@@ -29,7 +33,12 @@ where
         required_value_degrees(group, solution, &entities, options.value_candidate_limit);
     let mut scalar_edits = Vec::new();
     let mut edited_entities = HashSet::new();
+    let mut batch_changes = Vec::new();
     for entity_index in entities {
+        if should_stop() {
+            state.rollback(group, solution, &mut batch_changes, 0);
+            return None;
+        }
         if state.current_value(entity_index).is_some() {
             continue;
         }
@@ -43,15 +52,23 @@ where
             &mut values,
         );
         for value in values {
+            if should_stop() {
+                state.rollback(group, solution, &mut batch_changes, 0);
+                return None;
+            }
             let Some(mov) = assignment_move_for_entity_value(
                 group,
                 solution,
                 state,
-                entity_index,
-                value,
+                AssignmentRequest::root(entity_index, value, options.max_depth),
                 options,
                 AssignmentMoveIntent::required(),
+                should_stop,
             ) else {
+                if should_stop() {
+                    state.rollback(group, solution, &mut batch_changes, 0);
+                    return None;
+                }
                 continue;
             };
             if mov
@@ -65,12 +82,22 @@ where
                 continue;
             }
             for edit in mov.edits() {
-                state.set_value(group, solution, edit.entity_index, edit.to_value);
+                state.set_value_recording(
+                    group,
+                    solution,
+                    edit.entity_index,
+                    edit.to_value,
+                    &mut batch_changes,
+                );
                 edited_entities.insert(edit.entity_index);
                 scalar_edits.push(group.edit(edit.entity_index, edit.to_value));
             }
             break;
         }
+    }
+    if should_stop() {
+        state.rollback(group, solution, &mut batch_changes, 0);
+        return None;
     }
     if scalar_edits.is_empty() {
         return None;

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_required_batch.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_required_batch.rs
@@ -26,11 +26,24 @@ where
     S: PlanningSolution,
     ShouldStop: FnMut() -> bool,
 {
-    let mut entities =
-        required_entities_by_scarcity(group, solution, state, options.value_candidate_limit);
+    let mut entities = required_entities_by_scarcity(
+        group,
+        solution,
+        state,
+        options.value_candidate_limit,
+        should_stop,
+    )?;
     order_candidates(&mut entities, options, 0xA551_6EED_0000_0004);
-    let value_degrees =
-        required_value_degrees(group, solution, &entities, options.value_candidate_limit);
+    if should_stop() {
+        return None;
+    }
+    let value_degrees = required_value_degrees(
+        group,
+        solution,
+        &entities,
+        options.value_candidate_limit,
+        should_stop,
+    )?;
     let mut scalar_edits = Vec::new();
     let mut edited_entities = HashSet::new();
     let mut batch_changes = Vec::new();

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_stream.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_stream.rs
@@ -141,31 +141,55 @@ where
         }
     }
 
-    pub(crate) fn next_move(&mut self) -> Option<CompoundScalarMove<S>> {
+    pub(crate) fn next_move_with_control<ShouldStop>(
+        &mut self,
+        should_stop: &mut ShouldStop,
+    ) -> Option<CompoundScalarMove<S>>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if should_stop() {
+            return None;
+        }
         if self.options.max_moves == 0 || self.yielded >= self.options.max_moves {
             return None;
         }
 
         if self.batch_required {
-            self.batch_required = false;
-            if let Some(candidate) =
-                required_batch_move(&self.group, &self.solution, &mut self.state, self.options)
-            {
+            let candidate = required_batch_move(
+                &self.group,
+                &self.solution,
+                &mut self.state,
+                self.options,
+                should_stop,
+            );
+            if let Some(candidate) = candidate {
+                self.batch_required = false;
                 self.seen.insert(normalized_move_key(&candidate));
                 self.yielded += 1;
                 return Some(candidate);
             }
+            if should_stop() {
+                return None;
+            }
+            self.batch_required = false;
         }
 
         let mut exhausted_turns = 0;
         while exhausted_turns < self.family_slots.len() {
+            if should_stop() {
+                return None;
+            }
             let slot_index = self.family_pos % self.family_slots.len();
             self.family_pos = (slot_index + 1) % self.family_slots.len();
             if self.family_slots[slot_index].exhausted {
                 exhausted_turns += 1;
                 continue;
             }
-            let Some(candidate) = self.next_slot_move(slot_index) else {
+            let Some(candidate) = self.next_slot_move(slot_index, should_stop) else {
+                if should_stop() {
+                    return None;
+                }
                 exhausted_turns += 1;
                 continue;
             };
@@ -179,7 +203,14 @@ where
         None
     }
 
-    fn next_slot_move(&mut self, slot_index: usize) -> Option<CompoundScalarMove<S>> {
+    fn next_slot_move<ShouldStop>(
+        &mut self,
+        slot_index: usize,
+        should_stop: &mut ShouldStop,
+    ) -> Option<CompoundScalarMove<S>>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
         if matches!(
             self.family_slots[slot_index].cursor,
             AssignmentFamilyCursor::Empty
@@ -197,9 +228,15 @@ where
 
         let candidate = {
             let cursor = &mut self.family_slots[slot_index].cursor;
-            next_family_move(cursor, &self.group, &self.solution, &mut self.state)
+            next_family_move(
+                cursor,
+                &self.group,
+                &self.solution,
+                &mut self.state,
+                should_stop,
+            )
         };
-        if candidate.is_none() {
+        if candidate.is_none() && !should_stop() {
             self.family_slots[slot_index].exhausted = true;
         }
         candidate
@@ -333,26 +370,31 @@ where
     }
 }
 
-fn next_family_move<S>(
+fn next_family_move<S, ShouldStop>(
     cursor: &mut AssignmentFamilyCursor,
     group: &ScalarAssignmentBinding<S>,
     solution: &S,
     state: &mut ScalarAssignmentState,
+    should_stop: &mut ShouldStop,
 ) -> Option<CompoundScalarMove<S>>
 where
     S: PlanningSolution,
+    ShouldStop: FnMut() -> bool,
 {
+    if should_stop() {
+        return None;
+    }
     match cursor {
         AssignmentFamilyCursor::EntityValues(entity_cursor) => {
-            let candidate = entity_cursor.next(group, solution, state);
-            if candidate.is_none() {
+            let candidate = entity_cursor.next(group, solution, state, should_stop);
+            if candidate.is_none() && !should_stop() {
                 *cursor = AssignmentFamilyCursor::Empty;
             }
             candidate
         }
         AssignmentFamilyCursor::Capacity(capacity_cursor) => {
-            let candidate = capacity_cursor.next(group, solution, state);
-            if candidate.is_none() {
+            let candidate = capacity_cursor.next(group, solution, state, should_stop);
+            if candidate.is_none() && !should_stop() {
                 *cursor = AssignmentFamilyCursor::Empty;
             }
             candidate

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_stream.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/assignment_stream.rs
@@ -216,7 +216,8 @@ where
             AssignmentFamilyCursor::Empty
         ) {
             let family = self.family_slots[slot_index].family;
-            self.family_slots[slot_index].cursor = self.open_family_cursor(family, self.options);
+            let cursor = self.open_family_cursor(family, self.options, should_stop)?;
+            self.family_slots[slot_index].cursor = cursor;
             if matches!(
                 self.family_slots[slot_index].cursor,
                 AssignmentFamilyCursor::Empty
@@ -242,18 +243,26 @@ where
         candidate
     }
 
-    fn open_family_cursor(
+    fn open_family_cursor<ShouldStop>(
         &mut self,
         family: AssignmentMoveFamily,
         options: ScalarAssignmentMoveOptions,
-    ) -> AssignmentFamilyCursor {
-        match family {
-            AssignmentMoveFamily::Required => AssignmentFamilyCursor::required_entity_values(
+        should_stop: &mut ShouldStop,
+    ) -> Option<AssignmentFamilyCursor>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if matches!(family, AssignmentMoveFamily::Required) {
+            return AssignmentFamilyCursor::required_entity_values(
                 &self.group,
                 &self.solution,
                 &self.state,
                 options,
-            ),
+                should_stop,
+            );
+        }
+        let cursor = match family {
+            AssignmentMoveFamily::Required => unreachable!("required cursor opened above"),
             AssignmentMoveFamily::OptionalAssign => AssignmentFamilyCursor::entity_values(
                 ordered_entities(&self.group, &self.solution, |entity_index| {
                     !self.state.is_required(entity_index)
@@ -366,6 +375,11 @@ where
                 CapacityCursor::new(&self.group, &self.solution, &self.state, options),
             ),
             AssignmentMoveFamily::Done => AssignmentFamilyCursor::Empty,
+        };
+        if should_stop() {
+            None
+        } else {
+            Some(cursor)
         }
     }
 }

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/mod.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/mod.rs
@@ -20,6 +20,9 @@ mod placement;
 mod placer;
 mod placer_stream;
 
+#[cfg(test)]
+mod tests;
+
 pub(crate) use assignment_candidate::ScalarAssignmentMoveOptions;
 pub(crate) use assignment_stream::ScalarAssignmentMoveCursor;
 pub(crate) use move_build::compound_move_for_group_candidate;

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/placement.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/placement.rs
@@ -88,23 +88,8 @@ pub(super) fn principal_assignment_edit<S>(
         .find(|edit| edit.entity_index == entity_index && edit.to_value.is_some())
 }
 
-pub(super) fn assignment_move_target<S>(
-    target: &crate::builder::ScalarGroupMemberBinding<S>,
-    group_slot: &ConstructionGroupSlotId,
-    mov: &CompoundScalarMove<S>,
-) -> ConstructionTarget {
-    let scalar_slots = mov
-        .edits()
-        .iter()
-        .filter(|edit| {
-            edit.descriptor_index == target.descriptor_index
-                && edit.variable_index == target.variable_index
-        })
-        .map(|edit| ConstructionSlotId::new(target.construction_binding_index(), edit.entity_index))
-        .collect::<Vec<_>>();
-    ConstructionTarget::new()
-        .with_scalar_slots(scalar_slots)
-        .with_group_slot(group_slot.clone())
+pub(super) fn assignment_move_target(group_slot: &ConstructionGroupSlotId) -> ConstructionTarget {
+    ConstructionTarget::new().with_group_slot(group_slot.clone())
 }
 
 pub(crate) fn scalar_group_move_strength<S>(mov: &CompoundScalarMove<S>, _solution: &S) -> i64

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/placer_stream.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/placer_stream.rs
@@ -131,6 +131,19 @@ where
     S: PlanningSolution + 'static,
 {
     fn next_candidate(&mut self) -> Option<CandidateId> {
+        self.next_candidate_with_control(&mut || false)
+    }
+
+    fn next_candidate_with_control<ShouldStop>(
+        &mut self,
+        should_stop: &mut ShouldStop,
+    ) -> Option<CandidateId>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if should_stop() {
+            return None;
+        }
         let (mov, target) = match &mut self.source {
             ScalarGroupCandidateSource::Empty => return None,
             ScalarGroupCandidateSource::Candidates { group, candidates } => {
@@ -150,7 +163,7 @@ where
                     first
                 } else {
                     let (entity_index, mov, target) =
-                        next_assignment_candidate(generator, completed_slots)?;
+                        next_assignment_candidate(generator, completed_slots, should_stop)?;
                     if entity_index != *active_entity {
                         generator.pending = Some(mov);
                         return None;
@@ -222,7 +235,7 @@ where
     let completed_slots = completed_assignment_slots(&generator, &mut is_completed);
     if generator.accepted < generator.options.max_moves && !should_stop() {
         let (entity_index, mov, target) =
-            next_assignment_candidate(&mut generator, &completed_slots)?;
+            next_assignment_candidate(&mut generator, &completed_slots, &mut should_stop)?;
         let group_slot = assignment_group_slot(generator.group_index, entity_index);
         let scalar_slots = target.scalar_slots().to_vec();
         let allows_unassigned = generator.assignment.target.allows_unassigned;
@@ -246,21 +259,27 @@ where
     None
 }
 
-fn next_assignment_candidate<S>(
+fn next_assignment_candidate<S, ShouldStop>(
     generator: &mut AssignmentPlacementGenerator<S>,
     completed_slots: &HashSet<ConstructionSlotId>,
+    should_stop: &mut ShouldStop,
 ) -> Option<(usize, CompoundScalarMove<S>, ConstructionTarget)>
 where
     S: PlanningSolution + 'static,
+    ShouldStop: FnMut() -> bool,
 {
     loop {
+        if should_stop() {
+            return None;
+        }
         if generator.accepted >= generator.options.max_moves {
             return None;
         }
-        let mov = generator
-            .pending
-            .take()
-            .or_else(|| generator.cursor.next_move())?;
+        let mov = if let Some(pending) = generator.pending.take() {
+            pending
+        } else {
+            generator.cursor.next_move_with_control(should_stop)?
+        };
         if mov.edits().iter().any(|edit| {
             completed_slots.contains(&ConstructionSlotId::new(
                 generator.assignment.target().construction_binding_index(),
@@ -281,7 +300,8 @@ where
         let anchor = mov
             .edits()
             .iter()
-            .find(|edit| edit.to_value.is_some())
+            .find(|edit| edit.current_value(snapshot).is_none() && edit.to_value.is_some())
+            .or_else(|| mov.edits().iter().find(|edit| edit.to_value.is_some()))
             .or_else(|| mov.edits().first())?;
         let entity_index = anchor.entity_index;
         let order_key = principal_assignment_edit(&mov, entity_index)
@@ -293,7 +313,7 @@ where
             });
         let mov = mov.with_construction_value_order_key(order_key);
         let group_slot = assignment_group_slot(generator.group_index, entity_index);
-        let target = assignment_move_target(generator.assignment.target(), &group_slot, &mov);
+        let target = assignment_move_target(&group_slot);
         return Some((entity_index, mov, target));
     }
 }

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/tests.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/tests.rs
@@ -11,6 +11,7 @@ use solverforge_core::score::SoftScore;
 use solverforge_scoring::ScoreDirector;
 
 use super::assignment_candidate::{AssignmentMoveIntent, ScalarAssignmentMoveOptions};
+use super::assignment_entity::required_value_degrees;
 use super::assignment_path::{assignment_move_for_entity_value, AssignmentRequest};
 use super::assignment_state::ScalarAssignmentState;
 use super::assignment_stream::ScalarAssignmentMoveCursor;
@@ -21,6 +22,7 @@ use crate::builder::{
 };
 use crate::descriptor::{collect_bindings, ResolvedVariableBinding};
 use crate::heuristic::selector::nearby_list_change::DefaultCrossEntityDistanceMeter;
+use crate::phase::control::GENERATION_POLL_INTERVAL;
 use crate::phase::Phase;
 use crate::planning::{ScalarGroup, ScalarGroupLimits, ScalarTarget};
 use crate::scope::SolverScope;
@@ -100,9 +102,19 @@ fn capacity_key(_: &AssignmentPlan, _: usize, value: usize) -> Option<usize> {
     Some(value)
 }
 
+type TestCandidateValues = for<'a> fn(&'a AssignmentPlan, usize, usize) -> &'a [usize];
+
 fn assignment_group(
     descriptor: &SolutionDescriptor,
     limits: ScalarGroupLimits,
+) -> ScalarGroupBinding<AssignmentPlan> {
+    assignment_group_with_candidate_values(descriptor, limits, candidates)
+}
+
+fn assignment_group_with_candidate_values(
+    descriptor: &SolutionDescriptor,
+    limits: ScalarGroupLimits,
+    candidate_values: TestCandidateValues,
 ) -> ScalarGroupBinding<AssignmentPlan> {
     let slot = ScalarVariableSlot::new(
         0,
@@ -113,11 +125,11 @@ fn assignment_group(
         current_value,
         set_value,
         ValueSource::EntitySlice {
-            values_for_entity: candidates,
+            values_for_entity: candidate_values,
         },
         true,
     )
-    .with_candidate_values(candidates);
+    .with_candidate_values(candidate_values);
     let groups = bind_scalar_groups(
         vec![ScalarGroup::assignment(
             "worker_assignment",
@@ -144,7 +156,15 @@ fn assignment_binding(
     descriptor: &SolutionDescriptor,
     limits: ScalarGroupLimits,
 ) -> ScalarAssignmentBinding<AssignmentPlan> {
-    let group = assignment_group(descriptor, limits);
+    assignment_binding_with_candidate_values(descriptor, limits, candidates)
+}
+
+fn assignment_binding_with_candidate_values(
+    descriptor: &SolutionDescriptor,
+    limits: ScalarGroupLimits,
+    candidate_values: TestCandidateValues,
+) -> ScalarAssignmentBinding<AssignmentPlan> {
+    let group = assignment_group_with_candidate_values(descriptor, limits, candidate_values);
     match group.kind {
         ScalarGroupBindingKind::Assignment(assignment) => assignment,
         ScalarGroupBindingKind::Candidates { .. } => {
@@ -274,4 +294,68 @@ fn interrupted_required_batch_can_resume_without_partial_state() {
         .next_move_with_control(&mut || false)
         .expect("required batch must restart after interrupted generation");
     assert_eq!(resumed.edits().len(), entity_total);
+}
+
+static PREPROCESSING_CANDIDATE_READS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+fn tracked_preprocessing_candidates(plan: &AssignmentPlan, entity: usize, _: usize) -> &[usize] {
+    let previous = PREPROCESSING_CANDIDATE_READS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(
+        previous, 0,
+        "degree preprocessing read candidates after control requested interruption"
+    );
+    &plan.candidates[entity]
+}
+
+#[test]
+fn required_batch_polls_control_between_scarcity_and_degree_preprocessing() {
+    PREPROCESSING_CANDIDATE_READS.store(0, std::sync::atomic::Ordering::SeqCst);
+    let descriptor = descriptor();
+    let limits = ScalarGroupLimits::new();
+    let assignment = assignment_binding_with_candidate_values(
+        &descriptor,
+        limits,
+        tracked_preprocessing_candidates,
+    );
+    let solution = AssignmentPlan {
+        score: None,
+        assignments: vec![None],
+        candidates: vec![vec![0]],
+    };
+    let options = ScalarAssignmentMoveOptions::for_construction(limits);
+    let mut cursor =
+        ScalarAssignmentMoveCursor::required_construction(assignment, solution, options);
+    let interrupted = cursor.next_move_with_control(&mut || {
+        PREPROCESSING_CANDIDATE_READS.load(std::sync::atomic::Ordering::SeqCst) >= 1
+    });
+
+    assert!(interrupted.is_none());
+    assert_eq!(
+        PREPROCESSING_CANDIDATE_READS.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+#[test]
+fn required_value_degrees_bounds_control_polling_for_dense_rows() {
+    let descriptor = descriptor();
+    let limits = ScalarGroupLimits::new();
+    let assignment = assignment_binding(&descriptor, limits);
+    let candidate_count = GENERATION_POLL_INTERVAL * 2;
+    let solution = AssignmentPlan {
+        score: None,
+        assignments: vec![None],
+        candidates: vec![(0..candidate_count).collect()],
+    };
+    let mut polls = 0;
+
+    let degrees = required_value_degrees(&assignment, &solution, &[0], None, &mut || {
+        polls += 1;
+        false
+    })
+    .expect("uninterrupted degree preprocessing must complete");
+
+    assert_eq!(degrees.len(), candidate_count);
+    assert_eq!(polls, 4, "poll once per row, interval, and final boundary");
 }

--- a/crates/solverforge-solver/src/phase/construction/grouped_scalar/tests.rs
+++ b/crates/solverforge-solver/src/phase/construction/grouped_scalar/tests.rs
@@ -1,0 +1,277 @@
+use std::any::{Any, TypeId};
+
+use solverforge_config::{
+    ConstructionHeuristicConfig, ConstructionHeuristicType, ConstructionObligation,
+};
+use solverforge_core::domain::{
+    EntityClassId, EntityCollectionExtractor, EntityDescriptor, PlanningSolution,
+    SolutionDescriptor, ValueRangeType, VariableDescriptor, VariableId,
+};
+use solverforge_core::score::SoftScore;
+use solverforge_scoring::ScoreDirector;
+
+use super::assignment_candidate::{AssignmentMoveIntent, ScalarAssignmentMoveOptions};
+use super::assignment_path::{assignment_move_for_entity_value, AssignmentRequest};
+use super::assignment_state::ScalarAssignmentState;
+use super::assignment_stream::ScalarAssignmentMoveCursor;
+use super::build_scalar_group_construction;
+use crate::builder::{
+    bind_scalar_groups, RuntimeModel, ScalarAssignmentBinding, ScalarGroupBinding,
+    ScalarGroupBindingKind, ScalarVariableSlot, ValueSource, VariableSlot,
+};
+use crate::descriptor::{collect_bindings, ResolvedVariableBinding};
+use crate::heuristic::selector::nearby_list_change::DefaultCrossEntityDistanceMeter;
+use crate::phase::Phase;
+use crate::planning::{ScalarGroup, ScalarGroupLimits, ScalarTarget};
+use crate::scope::SolverScope;
+
+#[derive(Clone, Debug)]
+struct AssignmentPlan {
+    score: Option<SoftScore>,
+    assignments: Vec<Option<usize>>,
+    candidates: Vec<Vec<usize>>,
+}
+
+impl PlanningSolution for AssignmentPlan {
+    type Score = SoftScore;
+
+    fn score(&self) -> Option<Self::Score> {
+        self.score
+    }
+
+    fn set_score(&mut self, score: Option<Self::Score>) {
+        self.score = score;
+    }
+}
+
+fn descriptor() -> SolutionDescriptor {
+    SolutionDescriptor::new("AssignmentPlan", TypeId::of::<AssignmentPlan>()).with_entity(
+        EntityDescriptor::new("Task", TypeId::of::<Option<usize>>(), "tasks")
+            .with_logical_id(EntityClassId(0))
+            .with_extractor(Box::new(EntityCollectionExtractor::new(
+                "Task",
+                "tasks",
+                |plan: &AssignmentPlan| &plan.assignments,
+                |plan: &mut AssignmentPlan| &mut plan.assignments,
+            )))
+            .with_variable(
+                VariableDescriptor::genuine("worker")
+                    .with_logical_id(VariableId(0))
+                    .with_allows_unassigned(true)
+                    .with_value_range_type(ValueRangeType::EntityDependent)
+                    .with_usize_accessors(assignment_getter, assignment_setter),
+            ),
+    )
+}
+
+fn assignment_getter(entity: &dyn Any) -> Option<usize> {
+    *entity
+        .downcast_ref::<Option<usize>>()
+        .expect("Task entity must be an optional worker")
+}
+
+fn assignment_setter(entity: &mut dyn Any, value: Option<usize>) {
+    *entity
+        .downcast_mut::<Option<usize>>()
+        .expect("Task entity must be an optional worker") = value;
+}
+
+fn entity_count(plan: &AssignmentPlan) -> usize {
+    plan.assignments.len()
+}
+
+fn current_value(plan: &AssignmentPlan, entity: usize, _: usize) -> Option<usize> {
+    plan.assignments[entity]
+}
+
+fn set_value(plan: &mut AssignmentPlan, entity: usize, _: usize, value: Option<usize>) {
+    plan.assignments[entity] = value;
+}
+
+fn candidates(plan: &AssignmentPlan, entity: usize, _: usize) -> &[usize] {
+    &plan.candidates[entity]
+}
+
+fn required(_: &AssignmentPlan, _: usize) -> bool {
+    true
+}
+
+fn capacity_key(_: &AssignmentPlan, _: usize, value: usize) -> Option<usize> {
+    Some(value)
+}
+
+fn assignment_group(
+    descriptor: &SolutionDescriptor,
+    limits: ScalarGroupLimits,
+) -> ScalarGroupBinding<AssignmentPlan> {
+    let slot = ScalarVariableSlot::new(
+        0,
+        0,
+        "Task",
+        entity_count,
+        "worker",
+        current_value,
+        set_value,
+        ValueSource::EntitySlice {
+            values_for_entity: candidates,
+        },
+        true,
+    )
+    .with_candidate_values(candidates);
+    let groups = bind_scalar_groups(
+        vec![ScalarGroup::assignment(
+            "worker_assignment",
+            ScalarTarget::from_descriptor_index(0, "worker"),
+        )
+        .with_required_entity(required)
+        .with_capacity_key(capacity_key)
+        .with_limits(limits)],
+        &[slot],
+    );
+    let model = RuntimeModel::<
+        AssignmentPlan,
+        usize,
+        DefaultCrossEntityDistanceMeter,
+        DefaultCrossEntityDistanceMeter,
+    >::new(vec![VariableSlot::Scalar(slot)])
+    .with_scalar_groups(groups)
+    .resolve_dynamic_descriptor_indexes(descriptor)
+    .expect("assignment model must resolve against its descriptor");
+    model.scalar_groups()[0].clone()
+}
+
+fn assignment_binding(
+    descriptor: &SolutionDescriptor,
+    limits: ScalarGroupLimits,
+) -> ScalarAssignmentBinding<AssignmentPlan> {
+    let group = assignment_group(descriptor, limits);
+    match group.kind {
+        ScalarGroupBindingKind::Assignment(assignment) => assignment,
+        ScalarGroupBindingKind::Candidates { .. } => {
+            panic!("test assignment group must bind assignment metadata")
+        }
+    }
+}
+
+#[test]
+fn required_construction_can_rematch_rows_assigned_by_its_batch_move() {
+    let descriptor = descriptor();
+    let group = assignment_group(
+        &descriptor,
+        ScalarGroupLimits {
+            max_augmenting_depth: Some(4),
+            max_rematch_size: Some(8),
+            ..ScalarGroupLimits::new()
+        },
+    );
+    let bindings = collect_bindings(&descriptor)
+        .into_iter()
+        .map(ResolvedVariableBinding::new)
+        .collect();
+    let input = AssignmentPlan {
+        score: None,
+        assignments: vec![None, None, None],
+        candidates: vec![vec![0, 2], vec![1, 2], vec![0, 1]],
+    };
+    let director = ScoreDirector::simple(input, descriptor, |plan, _| plan.assignments.len());
+    let mut scope = SolverScope::new(director);
+    let config = ConstructionHeuristicConfig {
+        construction_heuristic_type: ConstructionHeuristicType::CheapestInsertion,
+        construction_obligation: ConstructionObligation::AssignWhenCandidateExists,
+        ..ConstructionHeuristicConfig::default()
+    };
+    let mut phase = build_scalar_group_construction(Some(&config), 0, group, bindings, true);
+
+    phase.solve(&mut scope);
+
+    let assignments = &scope.working_solution().assignments;
+    assert!(
+        assignments.iter().all(Option::is_some),
+        "required construction left assignments incomplete: {assignments:?}"
+    );
+    let mut assigned_values = assignments.iter().copied().flatten().collect::<Vec<_>>();
+    assigned_values.sort_unstable();
+    assert_eq!(assigned_values, vec![0, 1, 2]);
+}
+
+#[test]
+fn augmenting_assignment_observes_control_during_recursive_search() {
+    let descriptor = descriptor();
+    let limits = ScalarGroupLimits {
+        max_augmenting_depth: Some(4),
+        max_rematch_size: Some(8),
+        ..ScalarGroupLimits::new()
+    };
+    let assignment = assignment_binding(&descriptor, limits);
+    let solution = AssignmentPlan {
+        score: None,
+        assignments: vec![Some(0), Some(1), None],
+        candidates: vec![vec![0, 2], vec![1, 2], vec![0, 1]],
+    };
+    let mut state = ScalarAssignmentState::new(&assignment, &solution);
+    let mut polls = 0;
+    let candidate = assignment_move_for_entity_value(
+        &assignment,
+        &solution,
+        &mut state,
+        AssignmentRequest::root(2, 0, limits.max_augmenting_depth.unwrap_or(3)),
+        ScalarAssignmentMoveOptions::for_construction(limits),
+        AssignmentMoveIntent::required(),
+        &mut || {
+            polls += 1;
+            polls >= 5
+        },
+    );
+
+    assert!(candidate.is_none());
+    assert!(polls >= 5, "control must be polled inside recursion");
+    assert_eq!(state.current_value(0), Some(0));
+    assert_eq!(state.current_value(1), Some(1));
+    assert_eq!(state.current_value(2), None);
+}
+
+#[test]
+fn interrupted_required_batch_can_resume_without_partial_state() {
+    let descriptor = descriptor();
+    let limits = ScalarGroupLimits {
+        max_augmenting_depth: Some(4),
+        max_rematch_size: Some(8),
+        ..ScalarGroupLimits::new()
+    };
+    let assignment = assignment_binding(&descriptor, limits);
+    let entity_total = 100;
+    let solution = AssignmentPlan {
+        score: None,
+        assignments: vec![None; entity_total],
+        candidates: (0..entity_total).map(|value| vec![value]).collect(),
+    };
+    let options = ScalarAssignmentMoveOptions::for_construction(limits);
+    let mut reference = ScalarAssignmentMoveCursor::required_construction(
+        assignment.clone(),
+        solution.clone(),
+        options,
+    );
+    let mut reference_polls = 0;
+    let complete = reference
+        .next_move_with_control(&mut || {
+            reference_polls += 1;
+            false
+        })
+        .expect("uninterrupted required batch must be generated");
+    assert_eq!(complete.edits().len(), entity_total);
+
+    let mut cursor =
+        ScalarAssignmentMoveCursor::required_construction(assignment, solution, options);
+    let mut polls = 0;
+
+    let interrupted = cursor.next_move_with_control(&mut || {
+        polls += 1;
+        polls >= reference_polls
+    });
+    assert!(interrupted.is_none());
+
+    let resumed = cursor
+        .next_move_with_control(&mut || false)
+        .expect("required batch must restart after interrupted generation");
+    assert_eq!(resumed.edits().len(), entity_total);
+}

--- a/crates/solverforge-solver/src/phase/construction/phase/tests/interruption.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase/tests/interruption.rs
@@ -200,3 +200,185 @@ fn pause_after_decisive_evaluation_snapshots_the_committed_selection() {
     }
     MANAGER.delete(job_id).expect("delete decisive job");
 }
+
+impl ConstructionPauseSolution {
+    fn best_fit_interrupted_pull(gate: BlockingEvaluationGate) -> Self {
+        Self {
+            eval_gate: Some(gate),
+            solvable_mode: ConstructionPauseSolvableMode::BestFitInterruptedPull,
+            ..Self::new(None)
+        }
+    }
+}
+
+fn solve_best_fit_interrupted_pull(
+    solver_scope: &mut SolverScope<'_, ConstructionPauseSolution, ConstructionPauseDirector>,
+    gate: Option<BlockingEvaluationGate>,
+) {
+    let placer = InterruptAfterRetainedCandidatePlacer {
+        gate: gate.expect("interrupted-pull solve requires a generation gate"),
+    };
+    let mut phase = ConstructionHeuristicPhase::new(placer, BestFitForager::new());
+    phase.solve(solver_scope);
+}
+
+struct InterruptAfterRetainedCandidateCursor {
+    candidate: Option<ConstructionPauseMove>,
+    pulled: bool,
+    gate: BlockingEvaluationGate,
+}
+
+impl InterruptAfterRetainedCandidateCursor {
+    fn new(gate: BlockingEvaluationGate) -> Self {
+        Self {
+            candidate: Some(ConstructionPauseMove::new(0, 7, true, None)),
+            pulled: false,
+            gate,
+        }
+    }
+}
+
+impl MoveCursor<ConstructionPauseSolution, ConstructionPauseMove>
+    for InterruptAfterRetainedCandidateCursor
+{
+    fn next_candidate(&mut self) -> Option<CandidateId> {
+        if self.pulled {
+            None
+        } else {
+            self.pulled = true;
+            Some(CandidateId::new(0))
+        }
+    }
+
+    fn next_candidate_with_control<ShouldStop>(
+        &mut self,
+        should_stop: &mut ShouldStop,
+    ) -> Option<CandidateId>
+    where
+        ShouldStop: FnMut() -> bool,
+    {
+        if !self.pulled {
+            return self.next_candidate();
+        }
+        self.gate.on_evaluation();
+        let _ = should_stop();
+        None
+    }
+
+    fn candidate(
+        &self,
+        id: CandidateId,
+    ) -> Option<MoveCandidateRef<'_, ConstructionPauseSolution, ConstructionPauseMove>> {
+        if id.index() != 0 {
+            return None;
+        }
+        self.candidate.as_ref().map(MoveCandidateRef::Borrowed)
+    }
+
+    fn take_candidate(&mut self, id: CandidateId) -> ConstructionPauseMove {
+        assert_eq!(id.index(), 0);
+        self.candidate
+            .take()
+            .expect("retained construction candidate must remain live")
+    }
+}
+
+#[derive(Clone, Debug)]
+struct InterruptAfterRetainedCandidatePlacer {
+    gate: BlockingEvaluationGate,
+}
+
+impl EntityPlacerCursor<ConstructionPauseSolution, ConstructionPauseMove>
+    for InterruptAfterRetainedCandidatePlacer
+{
+    type CandidateCursor = InterruptAfterRetainedCandidateCursor;
+
+    fn next_placement<D, IsCompleted, ShouldStop>(
+        &mut self,
+        _score_director: &D,
+        mut is_completed: IsCompleted,
+        mut should_stop: ShouldStop,
+    ) -> Option<Placement<ConstructionPauseSolution, ConstructionPauseMove, Self::CandidateCursor>>
+    where
+        D: Director<ConstructionPauseSolution>,
+        IsCompleted: FnMut(
+            &Placement<ConstructionPauseSolution, ConstructionPauseMove, Self::CandidateCursor>,
+        ) -> bool,
+        ShouldStop: FnMut() -> bool,
+    {
+        if should_stop() {
+            return None;
+        }
+        let placement = Placement::new(
+            EntityReference::new(0, 0),
+            InterruptAfterRetainedCandidateCursor::new(self.gate.clone()),
+        )
+        .with_slot_id(crate::phase::construction::ConstructionSlotId::new(0, 0));
+        (!is_completed(&placement)).then_some(placement)
+    }
+}
+
+impl EntityPlacer<ConstructionPauseSolution, ConstructionPauseMove>
+    for InterruptAfterRetainedCandidatePlacer
+{
+    type Cursor<'a>
+        = Self
+    where
+        Self: 'a;
+
+    fn open_cursor<'a, D: Director<ConstructionPauseSolution>>(
+        &'a self,
+        _score_director: &D,
+    ) -> Self::Cursor<'a> {
+        Self {
+            gate: self.gate.clone(),
+        }
+    }
+}
+
+#[test]
+fn paused_candidate_pull_restarts_without_committing_or_completing_retained_selection() {
+    static MANAGER: SolverManager<ConstructionPauseSolution> = SolverManager::new();
+
+    let gate = BlockingEvaluationGate::new(1);
+    let (job_id, mut receiver) = MANAGER
+        .solve(ConstructionPauseSolution::best_fit_interrupted_pull(
+            gate.clone(),
+        ))
+        .expect("interrupted-pull construction job should start");
+    gate.wait_until_blocked();
+    MANAGER.pause(job_id).expect("pause should be accepted");
+    assert!(matches!(
+        receiver.blocking_recv().expect("pause requested event"),
+        SolverEvent::PauseRequested { .. }
+    ));
+    gate.release();
+
+    let paused_revision = match receiver.blocking_recv().expect("paused event") {
+        SolverEvent::Paused { metadata } => metadata
+            .snapshot_revision
+            .expect("paused snapshot revision"),
+        other => panic!("unexpected event: {other:?}"),
+    };
+    let paused_snapshot = MANAGER
+        .get_snapshot(job_id, Some(paused_revision))
+        .expect("paused snapshot");
+
+    MANAGER.resume(job_id).expect("resume should be accepted");
+    assert!(matches!(
+        receiver.blocking_recv().expect("resumed event"),
+        SolverEvent::Resumed { .. }
+    ));
+    let completed_solution = match receiver.blocking_recv().expect("completed event") {
+        SolverEvent::Completed { solution, .. } => solution,
+        other => panic!("unexpected event: {other:?}"),
+    };
+    MANAGER.delete(job_id).expect("delete resumed job");
+
+    assert_eq!(paused_snapshot.solution.entities[0].value, None);
+    assert_eq!(paused_snapshot.telemetry.moves_generated, 1);
+    assert_eq!(paused_snapshot.telemetry.moves_evaluated, 1);
+    assert_eq!(paused_snapshot.telemetry.moves_accepted, 0);
+    assert_eq!(paused_snapshot.telemetry.moves_applied, 0);
+    assert_eq!(completed_solution.entities[0].value, Some(7));
+}

--- a/crates/solverforge-solver/src/phase/construction/phase/tests/support.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase/tests/support.rs
@@ -31,6 +31,7 @@ enum ConstructionPauseSolvableMode {
     FirstFitMax64,
     FirstFitDecisive,
     BestFitKeepCurrent,
+    BestFitInterruptedPull,
 }
 
 impl ConstructionPauseSolution {
@@ -463,6 +464,9 @@ impl Solvable for ConstructionPauseSolution {
                     BestFitForager::new(),
                 );
                 phase.solve(&mut solver_scope);
+            }
+            ConstructionPauseSolvableMode::BestFitInterruptedPull => {
+                solve_best_fit_interrupted_pull(&mut solver_scope, eval_gate)
             }
         }
 


### PR DESCRIPTION
## Summary

- complete required grouped-assignment construction while preserving group-scoped rematching
- propagate interrupted controlled cursor pulls through the construction phase restart path
- make scarcity and degree preprocessing control-aware with bounded dense-edge polling
- document the public controlled cursor contract in Rustdocs and the solver wireframe

## Root cause

`next_candidate_with_control()` uses `None` for both genuine exhaustion and requested interruption. Construction foragers treated every `None` as exhaustion, so they could resolve `KeepCurrent` or commit a retained candidate across a pause boundary. Required-assignment preprocessing also had an unpolled input-sized block; the first draft corrected that with a control check per candidate edge, which made dense domains pay for atomics and clock reads on every edge.

## Impact

Interrupted candidate generation now returns through the existing phase restart path before any selection is resolved or slot completion is recorded. Required preprocessing observes configured termination and pause requests while polling dense degree scans only every `GENERATION_POLL_INTERVAL`, plus row and final boundaries. The canonical `MoveCursor` API map now records the controlled method and its ambiguous `None` outcome.

## Validation

- `cargo test -p solverforge-solver phase::construction` (59 passed)
- `cargo test -p solverforge-solver --all-features` (706 unit tests and 31 doctests passed)
- `cargo clippy -p solverforge-solver --all-features --all-targets -- -D warnings`
- `make test-doc`
- `make build`
- `make examples`
- `RUST_TEST_THREADS=1 make pre-release`
- `git diff --check`
