### PR TITLE
fix(solver): stream construction progress through the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,12 @@ pipeline. Retained status/events expose generated, evaluated, and accepted move
 counts together with generation and evaluation durations; human-facing
 `moves/s` remains a display-only derived value.
 
+Generic and specialized construction phases publish the same engine-owned
+lifecycle and progress telemetry as local search. With verbose logging, the
+first observed phase work is reported promptly and long-running phases continue
+at roughly one-second intervals; Rust applications and host-language bindings
+consume those same events without synthesizing construction output.
+
 Neighborhood selector cleanup is benchmark-gated in the runtime crates. Shared
 support code backs exact sizing and reusable bookkeeping, while the
 move-enumeration hot loops for list and sublist neighborhoods stay explicit and
@@ -339,7 +345,7 @@ monomorphized.
 | Feature | Description |
 |---------|-------------|
 | `console` | Colorful console output with progress tracking |
-| `verbose-logging` | DEBUG-level phase progress updates (1/sec during long-running work) |
+| `verbose-logging` | DEBUG-level construction and local-search progress: prompt first work, then about once/sec during long-running phases |
 | `decimal` | Forwards the currently empty `solverforge-core/decimal` feature; fixed-scale `HardSoftDecimalScore` is always available |
 | `serde` | Serialization support for score types |
 
@@ -421,6 +427,7 @@ models show average `candidates`.
 
   0.000s ▶ Solving │ 14 entities │ 5 candidates │ scale 9.799 x 10^0
   0.001s ▶ Construction Heuristic started
+  0.001s ⚡ Construction Heuristic │          0 steps │       14,000/s │ 1 moves │ 0 accepted │ 1 calcs │ 0.0% │ -14hard/0soft │ 1 generated
   0.002s ◀ Construction Heuristic ended │ 1ms │ 14 steps │ 14,000 moves/s │ 14 moves │ 14 generated │ 14 accepted moves │ 14 calcs │ 0hard/-50soft
   0.002s ▶ Local Search started │ 0hard/-50soft
   1.002s ⚡    12,456 steps │      445,000/s │ 12,456 moves │ 1,234 accepted │ 12,456 calcs │ 9.9% │ -2hard/8soft │ 12,456 generated
@@ -449,7 +456,7 @@ models show average `candidates`.
 | Level | Content | When |
 |-------|---------|------|
 | INFO | Lifecycle events (solve/phase start/end) | Default |
-| DEBUG | Phase progress updates (1/sec with phase, speed, and score) | `verbose-logging` feature |
+| DEBUG | Construction and local-search progress: prompt first work, then about once/sec with phase, speed, and score | `verbose-logging` feature |
 | TRACE | Individual move evaluations | `RUST_LOG=solverforge_solver=trace` |
 
 ## Architecture

--- a/crates/solverforge-console/WIREFRAME.md
+++ b/crates/solverforge-console/WIREFRAME.md
@@ -60,7 +60,7 @@ The formatter recognizes these `event` field values:
 | `solve_start` | Solve banner line with entity count, list element or scalar candidate count, problem scale, optional constraint count, and optional time limit |
 | `phase_start` | Phase start line, including score when the event carries `score` |
 | `phase_end` | Phase end line with duration, steps, throughput, accepted/generated/evaluated counts, score calculations, generation/evaluation time, and score |
-| `progress` | Periodic progress line with phase name, steps, speed, evaluated/accepted/generated move counts, score calculations, acceptance rate, current score, and best score when distinct |
+| `progress` | Prompt first-work and then periodic construction/local-search progress with phase name, steps, speed, evaluated/accepted/generated move counts, score calculations, acceptance rate, current score, and best score when distinct |
 | `step` | TRACE-only individual move evaluation line keyed by `move_index` |
 | `solve_end` | Final solve line and summary box with score, generated/evaluated/accepted move counts, step count, score calculations, timing, throughput, and acceptance rate |
 
@@ -70,6 +70,7 @@ solves render `candidates`.
 ## Architectural Notes
 
 - **Formatting-only crate.** Solver behavior, telemetry collection, and lifecycle state live in `solverforge-solver`.
+- **Shared engine events.** Generic and specialized construction kernels publish the same structured lifecycle and progress events consumed by Rust applications and host-language bindings; the console does not synthesize construction steps.
 - **Version line uses crate metadata.** The banner reads `env!("CARGO_PKG_VERSION")`, so release bumps update console output through normal Cargo metadata.
 - **Subscriber setup is idempotent.** `init()` uses `OnceLock` and can be called multiple times safely.
 - **No solver dependency.** The crate consumes structured tracing fields and does not depend on solver internals.

--- a/crates/solverforge-solver/WIREFRAME.md
+++ b/crates/solverforge-solver/WIREFRAME.md
@@ -235,6 +235,7 @@ src/
 │   │   ├── slot.rs                      — ConstructionSlotId, exact-keyed ConstructionGroupSlotId, ConstructionGroupSlotKey, and ConstructionListElementId for construction frontier tracking
 │   │   ├── runtime_slots.rs             — Canonical scalar/list/mixed runtime-slot construction root
 │   │   ├── runtime_slots/*.rs           — Global placement, move, and per-slot construction chunks
+│   │   ├── telemetry.rs                 — Shared construction lifecycle events, candidate counters, and bounded progress polling
 │   │   ├── grouped_scalar/mod.rs        — Atomic grouped scalar construction module root over declared ScalarGroup candidates and assignment groups bound to runtime scalar slots
 │   │   ├── grouped_scalar/assignment_candidate.rs — Assignment move options, required assignment moves, capacity-conflict moves, reassignment moves, and remaining-required telemetry
 │   │   ├── grouped_scalar/assignment_block.rs — Required-assignment block planning helpers

--- a/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright/completion.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright/completion.rs
@@ -8,6 +8,7 @@ use super::{
     insertion_delta, owner_allows, route_owner_allows, ClarkeWrightAccess, CompletionAssignment,
     RuntimeListSourceIndex,
 };
+use crate::phase::construction::record_construction_candidate;
 use crate::scope::{PhaseScope, ProgressCallback, StepControlPolicy};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTracePullToken,
@@ -120,6 +121,11 @@ where
                             CandidateTraceDisposition::ForagerIgnored,
                         );
                     }
+                    record_construction_candidate(
+                        phase_scope,
+                        std::time::Duration::ZERO,
+                        std::time::Duration::ZERO,
+                    );
                     continue;
                 }
 
@@ -141,6 +147,11 @@ where
                             CandidateTraceDisposition::ForagerIgnored,
                         );
                     }
+                    record_construction_candidate(
+                        phase_scope,
+                        std::time::Duration::ZERO,
+                        std::time::Duration::ZERO,
+                    );
                     continue;
                 }
 
@@ -159,6 +170,11 @@ where
                         CandidateTraceDisposition::Evaluated,
                     );
                 }
+                record_construction_candidate(
+                    phase_scope,
+                    std::time::Duration::ZERO,
+                    std::time::Duration::ZERO,
+                );
                 let candidate_key = (delta, assignment.route_indices.len(), assignment_idx);
                 let best_key = best.map(|(delta, assignment_idx, _, _)| {
                     (
@@ -189,6 +205,7 @@ where
             phase_scope
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::Selected);
         }
+        phase_scope.record_move_accepted();
         assignments[assignment_idx]
             .route_indices
             .insert(insert_idx, element_idx);
@@ -196,6 +213,7 @@ where
             phase_scope
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::Applied);
         }
+        phase_scope.record_move_applied();
     }
 
     Some(

--- a/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright/kernel.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright/kernel.rs
@@ -15,6 +15,7 @@ use super::route_state::{
 };
 use super::savings::{sort_savings, SavingsEntry};
 use super::{owner_allows, ClarkeWrightAccess, RuntimeListSourceIndex, SourceElement};
+use crate::phase::construction::run_construction_phase;
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -37,8 +38,34 @@ pub(crate) fn run_clarke_wright<S, A, D, BestCb>(
     D: Director<S>,
     BestCb: ProgressCallback<S>,
 {
-    let mut phase_scope =
-        PhaseScope::with_phase_type(solver_scope, 0, "Clarke-Wright Construction");
+    run_construction_phase(
+        solver_scope,
+        0,
+        "Clarke-Wright Construction",
+        |phase_scope| {
+            run_clarke_wright_in_phase(
+                access,
+                source_index,
+                bound_unassigned,
+                control_policy,
+                phase_scope,
+            );
+        },
+    );
+}
+
+fn run_clarke_wright_in_phase<S, A, D, BestCb>(
+    access: &A,
+    source_index: &RuntimeListSourceIndex<A::Element>,
+    bound_unassigned: &[SourceElement<A::Element>],
+    control_policy: StepControlPolicy,
+    phase_scope: &mut PhaseScope<'_, '_, S, D, BestCb>,
+) where
+    S: PlanningSolution,
+    A: ClarkeWrightAccess<S>,
+    D: Director<S>,
+    BestCb: ProgressCallback<S>,
+{
     let solution = phase_scope.score_director().working_solution();
     let n_entities = access.entity_count(solution);
     let n_elements = source_index.source_count();
@@ -370,7 +397,7 @@ pub(crate) fn run_clarke_wright<S, A, D, BestCb>(
         && owner_ineligible_routes == 0
     {
         complete_routes_by_insertion(
-            &mut phase_scope,
+            phase_scope,
             access,
             source_index,
             &owner_slots,
@@ -400,7 +427,7 @@ pub(crate) fn run_clarke_wright<S, A, D, BestCb>(
 
     if let Some(completed_routes) = completion_routes {
         let descriptor_index = access.descriptor_index();
-        let mut step_scope = StepScope::new_with_control_policy(&mut phase_scope, control_policy);
+        let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
         step_scope.apply_committed_change(|director| {
             for (entity_idx, route) in completed_routes {
                 director.before_variable_changed(descriptor_index, entity_idx);
@@ -413,7 +440,7 @@ pub(crate) fn run_clarke_wright<S, A, D, BestCb>(
         step_scope.complete();
     } else if matched_count > 0 {
         let descriptor_index = access.descriptor_index();
-        let mut step_scope = StepScope::new_with_control_policy(&mut phase_scope, control_policy);
+        let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
         step_scope.apply_committed_change(|director| {
             for (index_route, entity_idx) in assignable_routes.into_iter().zip(route_to_owner) {
                 let Some(entity_idx) = entity_idx else {

--- a/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright/kernel.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_clarke_wright/kernel.rs
@@ -15,7 +15,7 @@ use super::route_state::{
 };
 use super::savings::{sort_savings, SavingsEntry};
 use super::{owner_allows, ClarkeWrightAccess, RuntimeListSourceIndex, SourceElement};
-use crate::phase::construction::run_construction_phase;
+use crate::phase::construction::{record_construction_candidate, run_construction_phase};
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -70,7 +70,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
     let n_entities = access.entity_count(solution);
     let n_elements = source_index.source_count();
     if n_entities == 0 || n_elements == 0 {
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -89,7 +89,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
         .collect::<Vec<_>>();
     if unassigned.is_empty() {
         tracing::info!("All elements already assigned, skipping Clarke-Wright construction");
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -99,7 +99,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
             unassigned_elements = unassigned.len(),
             "ListClarkeWright found no empty entity slots for remaining work; leaving preassigned routes untouched"
         );
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -191,6 +191,11 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
                         CandidateTraceDisposition::ForagerIgnored,
                     );
                 }
+                record_construction_candidate(
+                    phase_scope,
+                    std::time::Duration::ZERO,
+                    std::time::Duration::ZERO,
+                );
                 if (savings.len() & 0x3FF) == 0
                     && control_policy.should_terminate_construction(phase_scope.solver_scope_mut())
                 {
@@ -233,6 +238,11 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
                     CandidateTraceDisposition::Evaluated,
                 );
             }
+            record_construction_candidate(
+                phase_scope,
+                std::time::Duration::ZERO,
+                std::time::Duration::ZERO,
+            );
             let (Some(ri), Some(rj)) = (route_of[entry.left_idx], route_of[entry.right_idx]) else {
                 if let Some(token) = trace_token {
                     phase_scope.record_candidate_trace_disposition(
@@ -329,6 +339,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
                 phase_scope
                     .record_candidate_trace_disposition(token, CandidateTraceDisposition::Selected);
             }
+            phase_scope.record_move_accepted();
             routes[ri].visits = test_ri;
             routes[ri].scored_metric_class = Some(entry.metric_class);
             routes[ri].feasible_for_all_owners = false;
@@ -346,6 +357,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
                 phase_scope
                     .record_candidate_trace_disposition(token, CandidateTraceDisposition::Applied);
             }
+            phase_scope.record_move_applied();
             merged_in_pass = true;
         }
         if construction_interrupted || !merged_in_pass {
@@ -359,7 +371,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
         .filter(|route| !route.visits.is_empty())
         .collect::<Vec<_>>();
     if construction_interrupted {
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -420,7 +432,7 @@ fn run_clarke_wright_in_phase<S, A, D, BestCb>(
             matched_routes = matched_count,
             "ListClarkeWright could not match every constructed route to a feasible empty entity"
         );
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/cheapest.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/cheapest.rs
@@ -11,8 +11,9 @@ use crate::builder::context::{
     RuntimeListSourceIndex,
 };
 use crate::list_placement::OwnerRestriction;
+use crate::phase::construction::run_construction_phase;
 use crate::phase::Phase;
-use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy};
+use crate::scope::{ProgressCallback, SolverScope, StepControlPolicy};
 
 mod kernel;
 mod live;
@@ -247,13 +248,18 @@ where
                 "ListCheapestInsertionPhase assignment refresh failed before phase execution: {error:?}"
             )
         });
-        let mut phase_scope =
-            PhaseScope::with_phase_type(solver_scope, 0, "Cheapest-Insertion Construction");
-        let mut observer = PhaseCheapestInsertionObserver::new(
-            &mut phase_scope,
-            StepControlPolicy::ObserveConfigLimits,
+        run_construction_phase(
+            solver_scope,
+            0,
+            "Cheapest-Insertion Construction",
+            |phase_scope| {
+                let mut observer = PhaseCheapestInsertionObserver::new(
+                    phase_scope,
+                    StepControlPolicy::ObserveConfigLimits,
+                );
+                run_cheapest(self, &source_index, &unassigned, &mut observer);
+            },
         );
-        run_cheapest(self, &source_index, &unassigned, &mut observer);
     }
 
     fn phase_type_name(&self) -> &'static str {

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/cheapest/live.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/cheapest/live.rs
@@ -1,10 +1,13 @@
 //! Live score-director observer for canonical cheapest insertion.
 
+use std::time::Instant;
+
 use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use super::super::ScoredListConstructionAccess;
 use super::kernel::{CheapestInsertionObserver, CheapestInsertionTrial};
+use crate::phase::construction::record_construction_candidate;
 use crate::scope::{PhaseScope, ProgressCallback, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTracePullToken,
@@ -65,6 +68,7 @@ where
         trial: CheapestInsertionTrial,
     ) -> (Option<S::Score>, Option<Self::Trial>) {
         let descriptor_index = access.descriptor_index();
+        let generation_started = Instant::now();
         let trace = self.phase_scope.record_candidate_operation(
             trial.source,
             None,
@@ -81,6 +85,8 @@ where
                 trial.insertion_index as u64,
             ],
         );
+        let generation_duration = generation_started.elapsed();
+        let evaluation_started = Instant::now();
         let score_state = self.phase_scope.score_director().snapshot_score_state();
         self.phase_scope
             .score_director_mut()
@@ -113,6 +119,11 @@ where
             self.phase_scope
                 .record_candidate_trace_disposition(trace, CandidateTraceDisposition::Evaluated);
         }
+        record_construction_candidate(
+            self.phase_scope,
+            generation_duration,
+            evaluation_started.elapsed(),
+        );
         (Some(score), trace)
     }
 
@@ -138,6 +149,7 @@ where
         let descriptor_index = access.descriptor_index();
         let mut step_scope =
             StepScope::new_with_control_policy(self.phase_scope, self.control_policy);
+        step_scope.phase_scope_mut().record_move_accepted();
         step_scope.apply_committed_change(|director| {
             director.before_variable_changed(descriptor_index, entity_index);
             access.insert_element(
@@ -148,6 +160,7 @@ where
             );
             director.after_variable_changed(descriptor_index, entity_index);
         });
+        step_scope.phase_scope_mut().record_move_applied();
         if let Some(trace) = trace {
             step_scope
                 .phase_scope_mut()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/cheapest/tests.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/cheapest/tests.rs
@@ -1,4 +1,5 @@
 use std::any::TypeId;
+use std::sync::{Arc, Mutex};
 
 use solverforge_core::domain::{PlanningSolution, SolutionDescriptor};
 use solverforge_core::score::{HardSoftScore, SoftScore};
@@ -9,7 +10,7 @@ use crate::builder::context::{bind_runtime_list_source, ListConstructionKernelEr
 use crate::builder::usize_element_source_key;
 use crate::manager::SolverTerminalReason;
 use crate::phase::Phase;
-use crate::scope::SolverScope;
+use crate::scope::{SolverProgressKind, SolverProgressRef, SolverScope};
 
 #[path = "tests/parity.rs"]
 mod parity;
@@ -188,6 +189,51 @@ fn public_cheapest_observes_ordinary_limits() {
         scope.terminal_reason(),
         SolverTerminalReason::TerminatedByConfig
     );
+}
+
+#[test]
+fn public_cheapest_streams_progress_from_the_first_candidate() {
+    let plan = Plan {
+        elements: vec![0],
+        routes: vec![Vec::new()],
+        score: None,
+    };
+    let progress_events = Arc::new(Mutex::new(Vec::new()));
+    let captured = Arc::clone(&progress_events);
+    let mut scope = SolverScope::new_with_callback(
+        director(plan, zero_score),
+        move |progress: SolverProgressRef<'_, Plan>| {
+            if progress.kind == SolverProgressKind::Progress {
+                captured
+                    .lock()
+                    .expect("progress recorder should lock")
+                    .push(
+                        progress
+                            .telemetry
+                            .phase
+                            .expect("construction progress should include phase telemetry"),
+                    );
+            }
+        },
+        None,
+        None,
+    );
+    scope.start_solving();
+    let mut phase = phase();
+
+    phase.solve(&mut scope);
+
+    let events = progress_events
+        .lock()
+        .expect("progress recorder should lock");
+    let first = events
+        .first()
+        .expect("the first evaluated construction candidate should publish progress");
+    assert_eq!(first.phase_type, "Cheapest-Insertion Construction");
+    assert!(first.moves_generated > 0);
+    assert!(first.moves_evaluated > 0);
+    assert!(scope.stats().moves_accepted > 0);
+    assert!(scope.stats().moves_applied > 0);
 }
 
 #[test]

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/evaluation.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/evaluation.rs
@@ -1,47 +1,68 @@
 //! Score-trial and selection primitives for canonical regret insertion.
 
+use std::time::Instant;
+
 use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use super::{candidate_entities, RegretAccess, RegretEvaluation, RegretValue};
 use crate::builder::context::SourceElement;
+use crate::phase::construction::record_construction_candidate;
 use crate::scope::{PhaseScope, ProgressCallback, StepControlPolicy};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTracePullToken,
     CandidateTraceSource,
 };
 
-pub(super) fn eval_insertion<S, A, D>(
+pub(super) fn eval_insertion<S, A, D, BestCb>(
     access: &A,
     entry: &SourceElement<A::Element>,
     entity_index: usize,
     position: usize,
-    score_director: &mut D,
+    phase_scope: &mut PhaseScope<'_, '_, S, D, BestCb>,
 ) -> S::Score
 where
     S: PlanningSolution,
     A: RegretAccess<S>,
     D: Director<S>,
+    BestCb: ProgressCallback<S>,
 {
+    let evaluation_started = Instant::now();
     let descriptor_index = access.descriptor_index();
-    let score_state = score_director.snapshot_score_state();
-    score_director.before_variable_changed(descriptor_index, entity_index);
+    let score_state = phase_scope.score_director().snapshot_score_state();
+    phase_scope
+        .score_director_mut()
+        .before_variable_changed(descriptor_index, entity_index);
     access.insert_element(
-        score_director.working_solution_mut(),
+        phase_scope.score_director_mut().working_solution_mut(),
         entity_index,
         position,
         entry.element.clone(),
     );
-    score_director.after_variable_changed(descriptor_index, entity_index);
-    let score = score_director.calculate_score();
-    score_director.before_variable_changed(descriptor_index, entity_index);
+    phase_scope
+        .score_director_mut()
+        .after_variable_changed(descriptor_index, entity_index);
+    let score = phase_scope.score_director_mut().calculate_score();
+    phase_scope
+        .score_director_mut()
+        .before_variable_changed(descriptor_index, entity_index);
     access.remove_element(
-        score_director.working_solution_mut(),
+        phase_scope.score_director_mut().working_solution_mut(),
         entity_index,
         position,
     );
-    score_director.after_variable_changed(descriptor_index, entity_index);
-    score_director.restore_score_state(score_state);
+    phase_scope
+        .score_director_mut()
+        .after_variable_changed(descriptor_index, entity_index);
+    phase_scope
+        .score_director_mut()
+        .restore_score_state(score_state);
+    phase_scope.record_score_calculation();
+    record_construction_candidate(
+        phase_scope,
+        std::time::Duration::ZERO,
+        evaluation_started.elapsed(),
+    );
     score
 }
 
@@ -151,14 +172,7 @@ where
                 entity_index,
                 position,
             );
-            let score = eval_insertion(
-                access,
-                entry,
-                entity_index,
-                position,
-                phase_scope.score_director_mut(),
-            );
-            phase_scope.record_score_calculation();
+            let score = eval_insertion(access, entry, entity_index, position, phase_scope);
             if let Some(token) = trace_token {
                 phase_scope.record_candidate_trace_disposition(
                     token,
@@ -250,14 +264,7 @@ where
             owner_index,
             position,
         );
-        let score = eval_insertion(
-            access,
-            entry,
-            owner_index,
-            position,
-            phase_scope.score_director_mut(),
-        );
-        phase_scope.record_score_calculation();
+        let score = eval_insertion(access, entry, owner_index, position, phase_scope);
         if let Some(token) = trace_token {
             phase_scope
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::Evaluated);

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/execute.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/execute.rs
@@ -11,6 +11,7 @@ use crate::stats::{CandidateTraceDisposition, CandidateTracePullToken};
 
 use super::fallback::solve_oversized_owner_restricted;
 use super::precedence::precedence_downstream_by_source;
+use crate::phase::construction::run_construction_phase;
 
 /// Runs the one canonical regret-insertion algorithm over a frozen source.
 ///
@@ -29,8 +30,34 @@ pub(crate) fn run_regret<S, A, D, BestCb>(
     D: Director<S>,
     BestCb: ProgressCallback<S>,
 {
-    let mut phase_scope =
-        PhaseScope::with_phase_type(solver_scope, 0, "Regret-Insertion Construction");
+    run_construction_phase(
+        solver_scope,
+        0,
+        "Regret-Insertion Construction",
+        |phase_scope| {
+            run_regret_in_phase(
+                access,
+                source_index,
+                bound_unassigned,
+                control_policy,
+                phase_scope,
+            );
+        },
+    );
+}
+
+fn run_regret_in_phase<S, A, D, BestCb>(
+    access: &A,
+    source_index: &RuntimeListSourceIndex<A::Element>,
+    bound_unassigned: &[SourceElement<A::Element>],
+    control_policy: StepControlPolicy,
+    phase_scope: &mut PhaseScope<'_, '_, S, D, BestCb>,
+) where
+    S: PlanningSolution,
+    A: RegretAccess<S>,
+    D: Director<S>,
+    BestCb: ProgressCallback<S>,
+{
     let source_count = source_index.source_count();
     let entity_count = access.entity_count(phase_scope.score_director().working_solution());
     if entity_count == 0 || source_count == 0 {
@@ -58,7 +85,7 @@ pub(crate) fn run_regret<S, A, D, BestCb>(
 
     if solve_oversized_owner_restricted(
         access,
-        &mut phase_scope,
+        phase_scope,
         source_index,
         &unassigned,
         entity_count,
@@ -87,19 +114,14 @@ pub(crate) fn run_regret<S, A, D, BestCb>(
                 interrupted = true;
                 break;
             }
-            let result = match evaluate_regret(
-                access,
-                entry,
-                entity_count,
-                control_policy,
-                &mut phase_scope,
-            ) {
-                RegretEvaluation::Complete(result) => result,
-                RegretEvaluation::Interrupted => {
-                    interrupted = true;
-                    break;
-                }
-            };
+            let result =
+                match evaluate_regret(access, entry, entity_count, control_policy, phase_scope) {
+                    RegretEvaluation::Complete(result) => result,
+                    RegretEvaluation::Interrupted => {
+                        interrupted = true;
+                        break;
+                    }
+                };
             let Some((regret, entity_index, position, score, trace_token)) = result else {
                 continue;
             };
@@ -159,7 +181,7 @@ pub(crate) fn run_regret<S, A, D, BestCb>(
             break;
         };
         let entry = unassigned.remove(list_index);
-        let mut step_scope = StepScope::new_with_control_policy(&mut phase_scope, control_policy);
+        let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/execute.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/execute.rs
@@ -61,13 +61,13 @@ fn run_regret_in_phase<S, A, D, BestCb>(
     let source_count = source_index.source_count();
     let entity_count = access.entity_count(phase_scope.score_director().working_solution());
     if entity_count == 0 || source_count == 0 {
-        phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
     if bound_unassigned.is_empty() {
         tracing::info!("All elements already assigned, skipping regret insertion");
-        phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -182,6 +182,7 @@ fn run_regret_in_phase<S, A, D, BestCb>(
         };
         let entry = unassigned.remove(list_index);
         let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
+        step_scope.phase_scope_mut().record_move_accepted();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()
@@ -190,6 +191,7 @@ fn run_regret_in_phase<S, A, D, BestCb>(
         step_scope.apply_committed_change(|director| {
             apply_insertion(access, &entry, entity_index, position, director);
         });
+        step_scope.phase_scope_mut().record_move_applied();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/fallback.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/fallback.rs
@@ -10,6 +10,7 @@ use super::{
 };
 use crate::builder::context::{RuntimeListSourceIndex, SourceElement};
 use crate::list_placement::OwnerRestriction;
+use crate::phase::construction::record_construction_candidate;
 use crate::scope::{PhaseScope, ProgressCallback, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -209,10 +210,17 @@ fn apply_owner_ordered_append<S, A, D, BestCb>(
             phase_scope
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::Selected);
         }
+        record_construction_candidate(
+            phase_scope,
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+        );
         let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
+        step_scope.phase_scope_mut().record_move_accepted();
         step_scope.apply_committed_change(|director| {
             apply_insertion(access, entry, owner, insertion_position, director);
         });
+        step_scope.phase_scope_mut().record_move_applied();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()
@@ -293,14 +301,7 @@ fn apply_owner_ordered_best_insertion<S, A, D, BestCb>(
                 owner,
                 position,
             );
-            let score = eval_insertion(
-                access,
-                entry,
-                owner,
-                position,
-                phase_scope.score_director_mut(),
-            );
-            phase_scope.record_score_calculation();
+            let score = eval_insertion(access, entry, owner, position, phase_scope);
             if let Some(token) = trace_token {
                 phase_scope.record_candidate_trace_disposition(
                     token,
@@ -327,6 +328,7 @@ fn apply_owner_ordered_best_insertion<S, A, D, BestCb>(
             continue;
         };
         let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
+        step_scope.phase_scope_mut().record_move_accepted();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()
@@ -335,6 +337,7 @@ fn apply_owner_ordered_best_insertion<S, A, D, BestCb>(
         step_scope.apply_committed_change(|director| {
             apply_insertion(access, entry, owner, position, director);
         });
+        step_scope.phase_scope_mut().record_move_applied();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/precedence.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/regret/kernel/precedence.rs
@@ -330,6 +330,7 @@ where
         let entry = &entries[entry_position];
         let owner = owners[entry_position];
         let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
+        step_scope.phase_scope_mut().record_move_accepted();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()
@@ -338,6 +339,7 @@ where
         step_scope.apply_committed_change(|director| {
             apply_insertion(access, entry, owner, position, director);
         });
+        step_scope.phase_scope_mut().record_move_applied();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/round_robin/kernel.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/round_robin/kernel.rs
@@ -5,7 +5,7 @@ use solverforge_scoring::Director;
 
 use crate::builder::context::SourceElement;
 use crate::list_placement::OwnerRestriction;
-use crate::phase::construction::run_construction_phase;
+use crate::phase::construction::{record_construction_candidate, run_construction_phase};
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -85,14 +85,14 @@ fn run_round_robin_in_phase<S, A, D, BestCb>(
     let n_entities = access.entity_count(phase_scope.score_director().working_solution());
 
     if n_entities == 0 || source_count == 0 {
-        phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
 
     if all_assigned {
         tracing::info!("All elements already assigned, skipping construction");
-        phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -142,13 +142,20 @@ fn run_round_robin_in_phase<S, A, D, BestCb>(
             phase_scope
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::Selected);
         }
+        record_construction_candidate(
+            phase_scope,
+            std::time::Duration::ZERO,
+            std::time::Duration::ZERO,
+        );
 
         let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
+        step_scope.phase_scope_mut().record_move_accepted();
         step_scope.apply_committed_change(|sd| {
             sd.before_variable_changed(descriptor_index, target_entity);
             access.append_element(sd.working_solution_mut(), target_entity, entry.element);
             sd.after_variable_changed(descriptor_index, target_entity);
         });
+        step_scope.phase_scope_mut().record_move_applied();
         if let Some(token) = trace_token {
             step_scope
                 .phase_scope_mut()

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/round_robin/kernel.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/round_robin/kernel.rs
@@ -5,6 +5,7 @@ use solverforge_scoring::Director;
 
 use crate::builder::context::SourceElement;
 use crate::list_placement::OwnerRestriction;
+use crate::phase::construction::run_construction_phase;
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -51,8 +52,36 @@ pub(crate) fn run_round_robin<S, A, D, BestCb>(
     D: Director<S>,
     BestCb: ProgressCallback<S>,
 {
-    let mut phase_scope =
-        PhaseScope::with_phase_type(solver_scope, 0, "Round-Robin List Construction");
+    run_construction_phase(
+        solver_scope,
+        0,
+        "Round-Robin List Construction",
+        |phase_scope| {
+            run_round_robin_in_phase(
+                access,
+                source_count,
+                all_assigned,
+                bound_unassigned,
+                control_policy,
+                phase_scope,
+            );
+        },
+    );
+}
+
+fn run_round_robin_in_phase<S, A, D, BestCb>(
+    access: &A,
+    source_count: usize,
+    all_assigned: bool,
+    bound_unassigned: &[SourceElement<A::Element>],
+    control_policy: StepControlPolicy,
+    phase_scope: &mut PhaseScope<'_, '_, S, D, BestCb>,
+) where
+    S: PlanningSolution,
+    A: RoundRobinAccess<S>,
+    D: Director<S>,
+    BestCb: ProgressCallback<S>,
+{
     let n_entities = access.entity_count(phase_scope.score_director().working_solution());
 
     if n_entities == 0 || source_count == 0 {
@@ -114,7 +143,7 @@ pub(crate) fn run_round_robin<S, A, D, BestCb>(
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::Selected);
         }
 
-        let mut step_scope = StepScope::new_with_control_policy(&mut phase_scope, control_policy);
+        let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
         step_scope.apply_committed_change(|sd| {
             sd.before_variable_changed(descriptor_index, target_entity);
             access.append_element(sd.working_solution_mut(), target_entity, entry.element);

--- a/crates/solverforge-solver/src/manager/phase_factory/list_construction/round_robin/tests.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_construction/round_robin/tests.rs
@@ -1,4 +1,6 @@
 use std::any::TypeId;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use solverforge_core::domain::{PlanningSolution, SolutionDescriptor};
 use solverforge_core::score::SoftScore;
@@ -8,7 +10,7 @@ use super::*;
 use crate::builder::usize_element_source_key;
 use crate::manager::SolverTerminalReason;
 use crate::phase::Phase;
-use crate::scope::SolverScope;
+use crate::scope::{SolverProgressKind, SolverProgressRef, SolverScope};
 
 #[derive(Clone)]
 struct Plan {
@@ -63,4 +65,42 @@ fn public_round_robin_observes_ordinary_limits() {
         scope.terminal_reason(),
         SolverTerminalReason::TerminatedByConfig
     );
+}
+
+#[test]
+fn public_round_robin_streams_progress_from_the_first_candidate() {
+    let plan = Plan {
+        elements: vec![0],
+        routes: vec![Vec::new()],
+        score: None,
+    };
+    let descriptor = SolutionDescriptor::new("Plan", TypeId::of::<Plan>());
+    let director = ScoreDirector::simple(plan, descriptor, |plan, _| plan.routes.len());
+    let progress_events = Arc::new(AtomicUsize::new(0));
+    let captured = Arc::clone(&progress_events);
+    let mut scope = SolverScope::new_with_callback(
+        director,
+        move |progress: SolverProgressRef<'_, Plan>| {
+            if progress.kind == SolverProgressKind::Progress {
+                let phase = progress
+                    .telemetry
+                    .phase
+                    .expect("construction progress should include phase telemetry");
+                assert_eq!(phase.phase_type, "Round-Robin List Construction");
+                assert!(phase.moves_generated > 0);
+                assert!(phase.moves_evaluated > 0);
+                captured.fetch_add(1, Ordering::SeqCst);
+            }
+        },
+        None,
+        None,
+    );
+    scope.start_solving();
+    let mut phase = phase();
+
+    phase.solve(&mut scope);
+
+    assert!(progress_events.load(Ordering::SeqCst) > 0);
+    assert!(scope.stats().moves_accepted > 0);
+    assert!(scope.stats().moves_applied > 0);
 }

--- a/crates/solverforge-solver/src/manager/phase_factory/list_k_opt/kernel.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_k_opt/kernel.rs
@@ -8,6 +8,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use super::super::distance_arithmetic::sum_two;
+use crate::phase::construction::run_construction_phase;
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -45,18 +46,31 @@ pub(crate) fn run_list_k_opt<S, A, D, BestCb>(
     D: Director<S>,
     BestCb: ProgressCallback<S>,
 {
+    run_construction_phase(solver_scope, 0, "List K-Opt", |phase_scope| {
+        run_list_k_opt_in_phase(access, k, control_policy, phase_scope);
+    });
+}
+
+fn run_list_k_opt_in_phase<S, A, D, BestCb>(
+    access: &A,
+    k: usize,
+    control_policy: StepControlPolicy,
+    phase_scope: &mut PhaseScope<'_, '_, S, D, BestCb>,
+) where
+    S: PlanningSolution,
+    A: ListKOptAccess<S>,
+    D: Director<S>,
+    BestCb: ProgressCallback<S>,
+{
     if k != 2 {
         tracing::warn!(
             k,
             "ListKOptPhase: only k=2 is implemented; skipping k-opt polishing"
         );
-        let mut phase_scope = PhaseScope::with_phase_type(solver_scope, 0, "List K-Opt");
         let _score = phase_scope.score_director_mut().calculate_score();
         phase_scope.update_best_solution();
         return;
     }
-
-    let mut phase_scope = PhaseScope::with_phase_type(solver_scope, 0, "List K-Opt");
 
     let n_entities = {
         let solution = phase_scope.score_director().working_solution();
@@ -191,8 +205,7 @@ pub(crate) fn run_list_k_opt<S, A, D, BestCb>(
         }
 
         if changed {
-            let mut step_scope =
-                StepScope::new_with_control_policy(&mut phase_scope, control_policy);
+            let mut step_scope = StepScope::new_with_control_policy(phase_scope, control_policy);
             step_scope.apply_committed_change(|sd| {
                 sd.before_variable_changed(descriptor_index, entity_idx);
                 access.replace_route(sd.working_solution_mut(), entity_idx, route);

--- a/crates/solverforge-solver/src/manager/phase_factory/list_k_opt/kernel.rs
+++ b/crates/solverforge-solver/src/manager/phase_factory/list_k_opt/kernel.rs
@@ -8,7 +8,7 @@ use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 
 use super::super::distance_arithmetic::sum_two;
-use crate::phase::construction::run_construction_phase;
+use crate::phase::construction::{record_construction_candidate, run_construction_phase};
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTraceSource,
@@ -67,7 +67,7 @@ fn run_list_k_opt_in_phase<S, A, D, BestCb>(
             k,
             "ListKOptPhase: only k=2 is implemented; skipping k-opt polishing"
         );
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -78,7 +78,7 @@ fn run_list_k_opt_in_phase<S, A, D, BestCb>(
     };
 
     if n_entities == 0 {
-        let _score = phase_scope.score_director_mut().calculate_score();
+        phase_scope.calculate_score();
         phase_scope.update_best_solution();
         return;
     }
@@ -154,6 +154,11 @@ fn run_list_k_opt_in_phase<S, A, D, BestCb>(
                             CandidateTraceDisposition::Evaluated,
                         );
                     }
+                    record_construction_candidate(
+                        phase_scope,
+                        std::time::Duration::ZERO,
+                        std::time::Duration::ZERO,
+                    );
                     if proposed_distance < current_distance {
                         route[i..=j].reverse();
                         if !access.route_feasible(
@@ -176,6 +181,7 @@ fn run_list_k_opt_in_phase<S, A, D, BestCb>(
                                 CandidateTraceDisposition::Selected,
                             );
                         }
+                        phase_scope.record_move_accepted();
                         improved = true;
                         changed = true;
                         if let Some(token) = trace_token {
@@ -184,6 +190,7 @@ fn run_list_k_opt_in_phase<S, A, D, BestCb>(
                                 CandidateTraceDisposition::Applied,
                             );
                         }
+                        phase_scope.record_move_applied();
                     } else if let Some(token) = trace_token {
                         phase_scope.record_candidate_trace_disposition(
                             token,

--- a/crates/solverforge-solver/src/phase/construction/forager_step.rs
+++ b/crates/solverforge-solver/src/phase/construction/forager_step.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use solverforge_config::ConstructionObligation;
 use solverforge_core::domain::PlanningSolution;
@@ -13,6 +13,7 @@ use super::evaluation::evaluate_trial_move;
 use super::{ConstructionChoice, Placement, StrongestFitForager, WeakestFitForager};
 use crate::heuristic::r#move::Move;
 use crate::heuristic::selector::move_selector::{CandidateId, MoveCursor};
+use crate::phase::construction::report_construction_progress_if_due;
 use crate::phase::control::{
     settle_construction_interrupt, should_interrupt_before_evaluation, StepInterrupt,
 };
@@ -100,14 +101,24 @@ where
     D: Director<S>,
     BestCb: ProgressCallback<S>,
 {
-    if step_scope.progress_polling_required() {
-        step_scope.phase_scope_mut().report_progress_if_due();
-    }
     should_interrupt_before_evaluation(step_scope)
         && matches!(
             settle_construction_interrupt(step_scope),
             StepInterrupt::TerminatePhase
         )
+}
+
+fn record_evaluated_candidate<S, D, BestCb>(
+    step_scope: &mut StepScope<'_, '_, '_, S, D, BestCb>,
+    duration: Duration,
+) where
+    S: PlanningSolution,
+    D: Director<S>,
+    BestCb: ProgressCallback<S>,
+{
+    let phase_scope = step_scope.phase_scope_mut();
+    phase_scope.record_evaluated_move(duration);
+    report_construction_progress_if_due(phase_scope);
 }
 
 #[allow(clippy::drop_non_drop)]
@@ -152,9 +163,7 @@ where
                 CandidateTraceDisposition::NotDoable,
                 step_scope,
             );
-            step_scope
-                .phase_scope_mut()
-                .record_evaluated_move(evaluation_started.elapsed());
+            record_evaluated_candidate(step_scope, evaluation_started.elapsed());
             continue;
         }
 
@@ -168,9 +177,7 @@ where
             drop(candidate);
             true
         };
-        step_scope
-            .phase_scope_mut()
-            .record_evaluated_move(evaluation_started.elapsed());
+        record_evaluated_candidate(step_scope, evaluation_started.elapsed());
         mark_candidate_disposition(
             placement,
             candidate_id,
@@ -243,18 +250,14 @@ where
                 CandidateTraceDisposition::NotDoable,
                 step_scope,
             );
-            step_scope
-                .phase_scope_mut()
-                .record_evaluated_move(evaluation_started.elapsed());
+            record_evaluated_candidate(step_scope, evaluation_started.elapsed());
             continue;
         }
         let score = evaluate_trial_move(step_scope.score_director_mut(), &candidate);
         drop(candidate);
         placement.record_candidate_score(candidate_id, score);
         step_scope.phase_scope_mut().record_score_calculation();
-        step_scope
-            .phase_scope_mut()
-            .record_evaluated_move(evaluation_started.elapsed());
+        record_evaluated_candidate(step_scope, evaluation_started.elapsed());
         mark_candidate_disposition(
             placement,
             candidate_id,
@@ -348,18 +351,14 @@ where
                 CandidateTraceDisposition::NotDoable,
                 step_scope,
             );
-            step_scope
-                .phase_scope_mut()
-                .record_evaluated_move(evaluation_started.elapsed());
+            record_evaluated_candidate(step_scope, evaluation_started.elapsed());
             continue;
         }
         let score = evaluate_trial_move(step_scope.score_director_mut(), &candidate);
         drop(candidate);
         placement.record_candidate_score(candidate_id, score);
         step_scope.phase_scope_mut().record_score_calculation();
-        step_scope
-            .phase_scope_mut()
-            .record_evaluated_move(evaluation_started.elapsed());
+        record_evaluated_candidate(step_scope, evaluation_started.elapsed());
         mark_candidate_disposition(
             placement,
             candidate_id,
@@ -473,9 +472,7 @@ where
                 CandidateTraceDisposition::NotDoable,
                 step_scope,
             );
-            step_scope
-                .phase_scope_mut()
-                .record_evaluated_move(evaluation_started.elapsed());
+            record_evaluated_candidate(step_scope, evaluation_started.elapsed());
             continue;
         }
         let candidate_strength = match candidate {
@@ -486,9 +483,7 @@ where
                 unreachable!("construction candidates are concrete atomic moves")
             }
         };
-        step_scope
-            .phase_scope_mut()
-            .record_evaluated_move(evaluation_started.elapsed());
+        record_evaluated_candidate(step_scope, evaluation_started.elapsed());
         mark_candidate_disposition(
             placement,
             candidate_id,

--- a/crates/solverforge-solver/src/phase/construction/mod.rs
+++ b/crates/solverforge-solver/src/phase/construction/mod.rs
@@ -41,4 +41,6 @@ pub(crate) use slot::{
     ConstructionGroupSlotId, ConstructionGroupSlotKey, ConstructionListElementId,
     ConstructionSlotId,
 };
-pub(crate) use telemetry::run_construction_phase;
+pub(crate) use telemetry::{
+    record_construction_candidate, report_construction_progress_if_due, run_construction_phase,
+};

--- a/crates/solverforge-solver/src/phase/construction/mod.rs
+++ b/crates/solverforge-solver/src/phase/construction/mod.rs
@@ -16,6 +16,7 @@ mod phase;
 mod placer;
 mod runtime_slots;
 mod slot;
+mod telemetry;
 
 pub use config::{ConstructionHeuristicConfig, ForagerType};
 pub use forager::{
@@ -40,3 +41,4 @@ pub(crate) use slot::{
     ConstructionGroupSlotId, ConstructionGroupSlotKey, ConstructionListElementId,
     ConstructionSlotId,
 };
+pub(crate) use telemetry::run_construction_phase;

--- a/crates/solverforge-solver/src/phase/construction/phase.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase.rs
@@ -7,20 +7,19 @@ use std::time::Instant;
 use solverforge_config::ConstructionObligation;
 use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
-use tracing::info;
 
 use crate::heuristic::r#move::Move;
 use crate::heuristic::selector::move_selector::MoveCursor;
 use crate::phase::construction::decision::keep_current_allowed;
 use crate::phase::construction::{
-    ConstructionChoice, ConstructionForager, ConstructionTarget, EntityPlacer, EntityPlacerCursor,
-    Placement,
+    run_construction_phase, ConstructionChoice, ConstructionForager, ConstructionTarget,
+    EntityPlacer, EntityPlacerCursor, Placement,
 };
 use crate::phase::control::{settle_construction_interrupt, StepInterrupt};
 use crate::phase::Phase;
 use crate::scope::ProgressCallback;
-use crate::scope::{PhaseScope, SolverScope, StepScope};
-use crate::stats::{format_duration, whole_units_per_second, CandidateTraceDisposition};
+use crate::scope::{SolverScope, StepScope};
+use crate::stats::CandidateTraceDisposition;
 
 include!("phase/phase_type.rs");
 include!("phase/selection.rs");

--- a/crates/solverforge-solver/src/phase/construction/phase/phase_type.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase/phase_type.rs
@@ -72,127 +72,90 @@ where
     Fo: ConstructionForager<S, M>,
 {
     fn solve(&mut self, solver_scope: &mut SolverScope<S, D, BestCb>) {
-        let mut phase_scope =
-            PhaseScope::with_phase_type(solver_scope, 0, "Construction Heuristic");
-        let phase_index = phase_scope.phase_index();
+        run_construction_phase(solver_scope, 0, "Construction Heuristic", |phase_scope| {
+            let mut placement_cursor = self.placer.open_cursor(phase_scope.score_director());
 
-        info!(
-            event = "phase_start",
-            phase = "Construction Heuristic",
-            phase_index = phase_index,
-        );
-
-        let mut placement_cursor = self.placer.open_cursor(phase_scope.score_director());
-
-        loop {
-            if phase_scope
-                .solver_scope_mut()
-                .should_terminate_construction()
-            {
-                break;
-            }
-
-            let placement_generation_started = Instant::now();
-            let mut placement_generation_interrupted = false;
-            let next_placement = placement_cursor.next_placement(
-                phase_scope.score_director(),
-                |placement| placement_completed(placement, phase_scope.solver_scope()),
-                || {
-                    let should_stop = phase_scope.solver_scope().work_should_stop();
-                    placement_generation_interrupted |= should_stop;
-                    should_stop
-                },
-            );
-            phase_scope.record_generation_time(placement_generation_started.elapsed());
-            let Some(mut placement) = next_placement else {
-                let terminated = phase_scope
+            loop {
+                if phase_scope
                     .solver_scope_mut()
-                    .should_terminate_construction();
-                if placement_generation_interrupted && !terminated {
-                    continue;
+                    .should_terminate_construction()
+                {
+                    break;
                 }
-                break;
-            };
 
-            let mut step_scope = StepScope::new(&mut phase_scope);
+                let placement_generation_started = Instant::now();
+                let mut placement_generation_interrupted = false;
+                let next_placement = placement_cursor.next_placement(
+                    phase_scope.score_director(),
+                    |placement| placement_completed(placement, phase_scope.solver_scope()),
+                    || {
+                        let should_stop = phase_scope.solver_scope().work_should_stop();
+                        placement_generation_interrupted |= should_stop;
+                        should_stop
+                    },
+                );
+                phase_scope.record_generation_time(placement_generation_started.elapsed());
+                let Some(mut placement) = next_placement else {
+                    let terminated = phase_scope
+                        .solver_scope_mut()
+                        .should_terminate_construction();
+                    if placement_generation_interrupted && !terminated {
+                        continue;
+                    }
+                    break;
+                };
 
-            // Time the whole streamed selection once. Per-candidate evaluation
-            // time is tracked separately, so the remainder is cursor generation
-            // and forager bookkeeping without a clock read for every tiny move.
-            let evaluation_before = step_scope.phase_scope().stats().evaluation_time();
-            let selection_started = Instant::now();
-            let selection_result = self.forager.select_move_index(
-                &mut placement,
-                self.construction_obligation,
-                &mut step_scope,
-            );
-            let selection_elapsed = selection_started.elapsed();
-            let evaluation_elapsed = step_scope
-                .phase_scope()
-                .stats()
-                .evaluation_time()
-                .saturating_sub(evaluation_before);
-            step_scope
-                .phase_scope_mut()
-                .record_generation_time(selection_elapsed.saturating_sub(evaluation_elapsed));
+                let mut step_scope = StepScope::new(phase_scope);
 
-            // Use forager to pick the best move index for this placement.
-            let selection = match selection_result {
-                Some(selection) => selection,
-                None => {
-                    match settle_construction_interrupt(&mut step_scope) {
+                // Time the whole streamed selection once. Per-candidate evaluation
+                // time is tracked separately, so the remainder is cursor generation
+                // and forager bookkeeping without a clock read for every tiny move.
+                let evaluation_before = step_scope.phase_scope().stats().evaluation_time();
+                let selection_started = Instant::now();
+                let selection_result = self.forager.select_move_index(
+                    &mut placement,
+                    self.construction_obligation,
+                    &mut step_scope,
+                );
+                let selection_elapsed = selection_started.elapsed();
+                let evaluation_elapsed = step_scope
+                    .phase_scope()
+                    .stats()
+                    .evaluation_time()
+                    .saturating_sub(evaluation_before);
+                step_scope
+                    .phase_scope_mut()
+                    .record_generation_time(selection_elapsed.saturating_sub(evaluation_elapsed));
+
+                // Use forager to pick the best move index for this placement.
+                let selection = match selection_result {
+                    Some(selection) => selection,
+                    None => match settle_construction_interrupt(&mut step_scope) {
                         StepInterrupt::Restart => {
                             continue;
                         }
                         StepInterrupt::TerminatePhase => break,
-                    }
-                }
-            };
+                    },
+                };
 
-            commit_selection(
-                &mut placement,
-                selection,
-                self.construction_obligation,
-                &mut step_scope,
-            );
+                commit_selection(
+                    &mut placement,
+                    selection,
+                    self.construction_obligation,
+                    &mut step_scope,
+                );
 
-            step_scope.complete();
-        }
+                step_scope.complete();
+            }
 
-        let previous_best_score = phase_scope.solver_scope().best_score().copied();
+            let previous_best_score = phase_scope.solver_scope().best_score().copied();
 
-        // Update best solution at end of phase
-        phase_scope.update_best_solution();
-        if phase_scope.solver_scope().current_score() == previous_best_score.as_ref() {
-            phase_scope.promote_current_solution_on_score_tie();
-        }
-
-        let best_score = phase_scope
-            .solver_scope()
-            .best_score()
-            .map(|s| format!("{}", s))
-            .unwrap_or_else(|| "none".to_string());
-
-        let duration = phase_scope.elapsed();
-        let steps = phase_scope.step_count();
-        let speed = whole_units_per_second(steps, duration);
-        let stats = phase_scope.stats();
-
-        info!(
-            event = "phase_end",
-            phase = "Construction Heuristic",
-            phase_index = phase_index,
-            duration = %format_duration(duration),
-            steps = steps,
-            moves_generated = stats.moves_generated,
-            moves_evaluated = stats.moves_evaluated,
-            moves_accepted = stats.moves_accepted,
-            score_calculations = stats.score_calculations,
-            generation_time = %format_duration(stats.generation_time()),
-            evaluation_time = %format_duration(stats.evaluation_time()),
-            speed = speed,
-            score = best_score,
-        );
+            // Update best solution at end of phase
+            phase_scope.update_best_solution();
+            if phase_scope.solver_scope().current_score() == previous_best_score.as_ref() {
+                phase_scope.promote_current_solution_on_score_tie();
+            }
+        });
     }
 
     fn phase_type_name(&self) -> &'static str {

--- a/crates/solverforge-solver/src/phase/construction/phase/tests/lifecycle.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase/tests/lifecycle.rs
@@ -36,7 +36,6 @@ fn construction_reports_progress_before_a_long_phase_ends() {
         ConstructionPauseDirector::new(solution),
         move |progress: crate::scope::SolverProgressRef<'_, ConstructionPauseSolution>| {
             if progress.kind == crate::scope::SolverProgressKind::Progress {
-                assert!(progress.telemetry.step_count > 0);
                 assert!(progress.telemetry.moves_evaluated > 0);
                 progress_events_for_callback.fetch_add(1, Ordering::SeqCst);
             }

--- a/crates/solverforge-solver/src/phase/construction/phase/tests/lifecycle.rs
+++ b/crates/solverforge-solver/src/phase/construction/phase/tests/lifecycle.rs
@@ -27,6 +27,37 @@ fn test_construction_phase_reports_one_best_solution_on_improvement() {
 }
 
 #[test]
+fn construction_reports_progress_for_a_single_first_fit_candidate() {
+    let progress_events = Arc::new(AtomicUsize::new(0));
+    let progress_events_for_callback = Arc::clone(&progress_events);
+    let mut solver_scope = SolverScope::new_with_callback(
+        create_simple_nqueens_director(1),
+        move |progress: crate::scope::SolverProgressRef<'_, NQueensSolution>| {
+            if progress.kind == crate::scope::SolverProgressKind::Progress {
+                let phase = progress
+                    .telemetry
+                    .phase
+                    .expect("construction progress should include phase telemetry");
+                assert_eq!(phase.phase_type, "Construction Heuristic");
+                assert_eq!(phase.moves_generated, 1);
+                assert_eq!(phase.moves_evaluated, 1);
+                progress_events_for_callback.fetch_add(1, Ordering::SeqCst);
+            }
+        },
+        None,
+        None,
+    );
+    solver_scope.start_solving();
+
+    let placer = create_placer(vec![0]);
+    let mut phase = ConstructionHeuristicPhase::new(placer, FirstFitForager::new());
+
+    phase.solve(&mut solver_scope);
+
+    assert_eq!(progress_events.load(Ordering::SeqCst), 1);
+}
+
+#[test]
 fn construction_reports_progress_before_a_long_phase_ends() {
     let gate = BlockingEvaluationGate::delaying(Duration::from_millis(400));
     let progress_events = Arc::new(AtomicUsize::new(0));

--- a/crates/solverforge-solver/src/phase/construction/runtime_slots/global.rs
+++ b/crates/solverforge-solver/src/phase/construction/runtime_slots/global.rs
@@ -15,7 +15,7 @@ use crate::builder::RuntimeScalarSlot;
 use crate::heuristic::r#move::Move;
 use crate::phase::construction::decision::{is_first_fit_improvement, keep_current_allowed};
 use crate::phase::construction::evaluation::evaluate_trial_move;
-use crate::phase::construction::run_construction_phase;
+use crate::phase::construction::{record_construction_candidate, run_construction_phase};
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTracePullToken,
@@ -656,7 +656,6 @@ where
         Some(target),
         move_,
     );
-    phase_scope.record_generated_move(std::time::Duration::ZERO);
     let started = Instant::now();
     if !move_.is_doable(phase_scope.score_director()) {
         if let Some(token) = trace {
@@ -665,12 +664,12 @@ where
             phase_scope
                 .record_candidate_trace_disposition(token, CandidateTraceDisposition::NotDoable);
         }
-        phase_scope.record_evaluated_move(started.elapsed());
+        record_construction_candidate(phase_scope, std::time::Duration::ZERO, started.elapsed());
         return None;
     }
     let score = evaluate_trial_move(phase_scope.score_director_mut(), move_);
     phase_scope.record_score_calculation();
-    phase_scope.record_evaluated_move(started.elapsed());
+    record_construction_candidate(phase_scope, std::time::Duration::ZERO, started.elapsed());
     if let Some(token) = trace {
         phase_scope.record_candidate_trace_disposition(token, CandidateTraceDisposition::Evaluated);
     }

--- a/crates/solverforge-solver/src/phase/construction/runtime_slots/global.rs
+++ b/crates/solverforge-solver/src/phase/construction/runtime_slots/global.rs
@@ -15,6 +15,7 @@ use crate::builder::RuntimeScalarSlot;
 use crate::heuristic::r#move::Move;
 use crate::phase::construction::decision::{is_first_fit_improvement, keep_current_allowed};
 use crate::phase::construction::evaluation::evaluate_trial_move;
+use crate::phase::construction::run_construction_phase;
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepScope};
 use crate::stats::{
     CandidateTraceConstructionTarget, CandidateTraceDisposition, CandidateTracePullToken,
@@ -55,51 +56,52 @@ where
         ),
         "global runtime-slot construction supports only its declared first-fit or cheapest-insertion schedules"
     );
-    let mut phase_scope = PhaseScope::with_phase_type(solver_scope, 0, "Construction Heuristic");
-    let previous_best_score = phase_scope.solver_scope().best_score().copied();
-    let mut ran_step = false;
-    loop {
-        if phase_scope
-            .solver_scope_mut()
-            .should_terminate_construction()
-        {
-            break;
-        }
-        let progress = match config.construction_heuristic_type {
-            ConstructionHeuristicType::FirstFit => first_fit_iteration(
-                &scalar_slots,
-                &list_slots,
-                &slot_order,
-                config.value_candidate_limit,
-                config.construction_obligation,
-                &mut phase_scope,
-            ),
-            ConstructionHeuristicType::CheapestInsertion => cheapest_iteration(
-                &scalar_slots,
-                &list_slots,
-                &slot_order,
-                config.value_candidate_limit,
-                config.construction_obligation,
-                &mut phase_scope,
-            ),
-            _ => unreachable!("global construction heuristic was validated above"),
-        };
-        match progress {
-            Iteration::None => break,
-            Iteration::CompletedOnly => ran_step = true,
-            Iteration::Candidate(candidate) => {
-                ran_step = true;
-                commit(candidate, &mut phase_scope);
+    run_construction_phase(solver_scope, 0, "Construction Heuristic", |phase_scope| {
+        let previous_best_score = phase_scope.solver_scope().best_score().copied();
+        let mut ran_step = false;
+        loop {
+            if phase_scope
+                .solver_scope_mut()
+                .should_terminate_construction()
+            {
+                break;
+            }
+            let progress = match config.construction_heuristic_type {
+                ConstructionHeuristicType::FirstFit => first_fit_iteration(
+                    &scalar_slots,
+                    &list_slots,
+                    &slot_order,
+                    config.value_candidate_limit,
+                    config.construction_obligation,
+                    phase_scope,
+                ),
+                ConstructionHeuristicType::CheapestInsertion => cheapest_iteration(
+                    &scalar_slots,
+                    &list_slots,
+                    &slot_order,
+                    config.value_candidate_limit,
+                    config.construction_obligation,
+                    phase_scope,
+                ),
+                _ => unreachable!("global construction heuristic was validated above"),
+            };
+            match progress {
+                Iteration::None => break,
+                Iteration::CompletedOnly => ran_step = true,
+                Iteration::Candidate(candidate) => {
+                    ran_step = true;
+                    commit(candidate, phase_scope);
+                }
             }
         }
-    }
-    if ran_step {
-        phase_scope.update_best_solution();
-        if phase_scope.solver_scope().current_score() == previous_best_score.as_ref() {
-            phase_scope.promote_current_solution_on_score_tie();
+        if ran_step {
+            phase_scope.update_best_solution();
+            if phase_scope.solver_scope().current_score() == previous_best_score.as_ref() {
+                phase_scope.promote_current_solution_on_score_tie();
+            }
         }
-    }
-    ran_step
+        ran_step
+    })
 }
 
 #[expect(

--- a/crates/solverforge-solver/src/phase/construction/telemetry.rs
+++ b/crates/solverforge-solver/src/phase/construction/telemetry.rs
@@ -1,9 +1,40 @@
+use std::time::Duration;
+
 use solverforge_core::domain::PlanningSolution;
 use solverforge_scoring::Director;
 use tracing::info;
 
 use crate::scope::{PhaseScope, ProgressCallback, SolverScope};
 use crate::stats::{format_duration, whole_units_per_second};
+
+const CONSTRUCTION_PROGRESS_POLL_INTERVAL: u64 = 256;
+
+pub(crate) fn record_construction_candidate<S, D, ProgressCb>(
+    phase_scope: &mut PhaseScope<'_, '_, S, D, ProgressCb>,
+    generation_duration: Duration,
+    evaluation_duration: Duration,
+) where
+    S: PlanningSolution,
+    D: Director<S>,
+    ProgressCb: ProgressCallback<S>,
+{
+    phase_scope.record_generated_move(generation_duration);
+    phase_scope.record_evaluated_move(evaluation_duration);
+    report_construction_progress_if_due(phase_scope);
+}
+
+pub(crate) fn report_construction_progress_if_due<S, D, ProgressCb>(
+    phase_scope: &mut PhaseScope<'_, '_, S, D, ProgressCb>,
+) where
+    S: PlanningSolution,
+    D: Director<S>,
+    ProgressCb: ProgressCallback<S>,
+{
+    let evaluated = phase_scope.stats().moves_evaluated;
+    if evaluated == 1 || evaluated.is_multiple_of(CONSTRUCTION_PROGRESS_POLL_INTERVAL) {
+        phase_scope.report_progress_if_due();
+    }
+}
 
 /// Runs one construction kernel inside the shared lifecycle telemetry boundary.
 ///

--- a/crates/solverforge-solver/src/phase/construction/telemetry.rs
+++ b/crates/solverforge-solver/src/phase/construction/telemetry.rs
@@ -1,0 +1,164 @@
+use solverforge_core::domain::PlanningSolution;
+use solverforge_scoring::Director;
+use tracing::info;
+
+use crate::scope::{PhaseScope, ProgressCallback, SolverScope};
+use crate::stats::{format_duration, whole_units_per_second};
+
+/// Runs one construction kernel inside the shared lifecycle telemetry boundary.
+///
+/// Construction implementations own their candidate and commit loops, while
+/// this boundary owns the structured phase events consumed by the console.
+pub(crate) fn run_construction_phase<S, D, ProgressCb, R>(
+    solver_scope: &mut SolverScope<'_, S, D, ProgressCb>,
+    phase_index: usize,
+    phase_type: &'static str,
+    run: impl FnOnce(&mut PhaseScope<'_, '_, S, D, ProgressCb>) -> R,
+) -> R
+where
+    S: PlanningSolution,
+    D: Director<S>,
+    ProgressCb: ProgressCallback<S>,
+{
+    let mut phase_scope = PhaseScope::with_phase_type(solver_scope, phase_index, phase_type);
+    info!(
+        event = "phase_start",
+        phase = phase_type,
+        phase_index = phase_index,
+    );
+
+    let result = run(&mut phase_scope);
+
+    let duration = phase_scope.elapsed();
+    let steps = phase_scope.step_count();
+    let stats = phase_scope.stats();
+    let moves_speed = whole_units_per_second(stats.moves_evaluated, duration);
+    let calc_speed = whole_units_per_second(stats.score_calculations, duration);
+    let acceptance_rate = stats.acceptance_rate() * 100.0;
+    let score = phase_scope
+        .solver_scope()
+        .best_score()
+        .or_else(|| phase_scope.solver_scope().current_score())
+        .map(ToString::to_string)
+        .unwrap_or_else(|| "none".to_string());
+
+    info!(
+        event = "phase_end",
+        phase = phase_type,
+        phase_index = phase_index,
+        duration = %format_duration(duration),
+        steps = steps,
+        moves_generated = stats.moves_generated,
+        moves_evaluated = stats.moves_evaluated,
+        moves_accepted = stats.moves_accepted,
+        score_calculations = stats.score_calculations,
+        generation_time = %format_duration(stats.generation_time()),
+        evaluation_time = %format_duration(stats.evaluation_time()),
+        moves_speed = moves_speed,
+        calc_speed = calc_speed,
+        acceptance_rate = format!("{acceptance_rate:.1}%"),
+        score = score,
+    );
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Id, Record};
+    use tracing::{Event, Metadata, Subscriber};
+
+    use super::run_construction_phase;
+    use crate::scope::SolverScope;
+    use crate::test_utils::create_minimal_director;
+
+    #[derive(Clone, Default)]
+    struct CaptureSubscriber {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct CapturedEvent {
+        event: Option<String>,
+        phase: Option<String>,
+        phase_index: Option<u64>,
+    }
+
+    impl Visit for CapturedEvent {
+        fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+            let value = format!("{value:?}").trim_matches('"').to_string();
+            match field.name() {
+                "event" => self.event = Some(value),
+                "phase" => self.phase = Some(value),
+                _ => {}
+            }
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            if field.name() == "phase_index" {
+                self.phase_index = Some(value);
+            }
+        }
+    }
+
+    impl Subscriber for CaptureSubscriber {
+        fn enabled(&self, _metadata: &Metadata<'_>) -> bool {
+            true
+        }
+
+        fn new_span(&self, _span: &Attributes<'_>) -> Id {
+            Id::from_u64(1)
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let mut captured = CapturedEvent::default();
+            event.record(&mut captured);
+            self.events.lock().unwrap().push(captured);
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn exit(&self, _span: &Id) {}
+    }
+
+    #[test]
+    fn construction_lifecycle_wraps_the_kernel_with_structured_events() {
+        let subscriber = CaptureSubscriber::default();
+        let captured = Arc::clone(&subscriber.events);
+        let mut solver_scope = SolverScope::new(create_minimal_director());
+        solver_scope.start_solving();
+
+        tracing::subscriber::with_default(subscriber, || {
+            run_construction_phase(&mut solver_scope, 3, "Test Construction", |phase_scope| {
+                phase_scope.calculate_score();
+                phase_scope.update_best_solution();
+            });
+        });
+
+        let events = captured.lock().unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0],
+            CapturedEvent {
+                event: Some("phase_start".to_string()),
+                phase: Some("Test Construction".to_string()),
+                phase_index: Some(3),
+            }
+        );
+        assert_eq!(
+            events[1],
+            CapturedEvent {
+                event: Some("phase_end".to_string()),
+                phase: Some("Test Construction".to_string()),
+                phase_index: Some(3),
+            }
+        );
+    }
+}

--- a/crates/solverforge-solver/src/runtime/compiler/executor/list_construction/phase.rs
+++ b/crates/solverforge-solver/src/runtime/compiler/executor/list_construction/phase.rs
@@ -12,7 +12,8 @@ use crate::builder::context::{
 };
 use crate::heuristic::selector::nearby_list_change::CrossEntityDistanceMeter;
 use crate::manager::{run_cheapest, PhaseCheapestInsertionObserver};
-use crate::scope::{PhaseScope, ProgressCallback, SolverScope, StepControlPolicy};
+use crate::phase::construction::run_construction_phase;
+use crate::scope::{ProgressCallback, SolverScope, StepControlPolicy};
 
 /// Executes canonical cheapest insertion against a caller-owned prepared
 /// source binding.
@@ -38,10 +39,15 @@ where
     D: Director<S>,
     ProgressCb: ProgressCallback<S>,
 {
-    let mut phase_scope =
-        PhaseScope::with_phase_type(solver_scope, 0, "Cheapest-Insertion Construction");
-    let mut observer = PhaseCheapestInsertionObserver::new(&mut phase_scope, control_policy);
-    run_cheapest(slot, source_index, unassigned, &mut observer);
+    run_construction_phase(
+        solver_scope,
+        0,
+        "Cheapest-Insertion Construction",
+        |phase_scope| {
+            let mut observer = PhaseCheapestInsertionObserver::new(phase_scope, control_policy);
+            run_cheapest(slot, source_index, unassigned, &mut observer);
+        },
+    );
     Ok(())
 }
 

--- a/crates/solverforge-solver/src/scope/solver/scope_core.rs
+++ b/crates/solverforge-solver/src/scope/solver/scope_core.rs
@@ -11,6 +11,7 @@ pub(crate) struct ProgressTick {
 struct ProgressPulse {
     phase_index: usize,
     phase_type: &'static str,
+    initial_report_pending: bool,
     next_deadline: Instant,
     last_reported_at: Instant,
     last_step_count: u64,
@@ -28,6 +29,7 @@ impl ProgressPulse {
         Self {
             phase_index,
             phase_type,
+            initial_report_pending: true,
             next_deadline: now + PROGRESS_INTERVAL,
             last_reported_at: now,
             last_step_count: step_count,
@@ -47,7 +49,9 @@ impl ProgressPulse {
             *self = Self::new(now, phase_index, phase_type, step_count, move_count);
             return None;
         }
-        if now < self.next_deadline {
+        let has_new_work = step_count > self.last_step_count || move_count > self.last_move_count;
+        let is_initial_report = self.initial_report_pending && has_new_work;
+        if !is_initial_report && now < self.next_deadline {
             return None;
         }
         let tick = ProgressTick {
@@ -58,8 +62,13 @@ impl ProgressPulse {
         self.last_reported_at = now;
         self.last_step_count = step_count;
         self.last_move_count = move_count;
-        while self.next_deadline <= now {
-            self.next_deadline += PROGRESS_INTERVAL;
+        if is_initial_report {
+            self.initial_report_pending = false;
+            self.next_deadline = now + PROGRESS_INTERVAL;
+        } else {
+            while self.next_deadline <= now {
+                self.next_deadline += PROGRESS_INTERVAL;
+            }
         }
         Some(tick)
     }

--- a/crates/solverforge-solver/src/scope/tests.rs
+++ b/crates/solverforge-solver/src/scope/tests.rs
@@ -1,6 +1,8 @@
 // Tests for scope types.
 
 use std::any::TypeId;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use super::*;
 use crate::manager::SolverTerminalReason;
@@ -202,6 +204,33 @@ fn phase_progress_elapsed_uses_the_pause_aware_solver_clock() {
     assert_eq!(phase.phase_type, "PauseAwarePhase");
     assert_eq!(phase.elapsed, frozen_elapsed);
     assert!(phase.elapsed < raw_after);
+}
+
+#[test]
+fn phase_progress_reports_first_real_work_then_resumes_the_time_cadence() {
+    let publications = Arc::new(AtomicUsize::new(0));
+    let captured = Arc::clone(&publications);
+    let callback = move |progress: SolverProgressRef<'_, TestSolution>| {
+        if progress.kind == SolverProgressKind::Progress {
+            captured.fetch_add(1, Ordering::SeqCst);
+        }
+    };
+    let mut solver_scope =
+        SolverScope::new_with_callback(create_minimal_director(), callback, None, None);
+    solver_scope.start_solving();
+
+    let mut phase_scope = PhaseScope::with_phase_type(&mut solver_scope, 0, "ImmediatePhase");
+    assert!(!phase_scope.report_progress_if_due());
+
+    phase_scope.record_generated_move(std::time::Duration::ZERO);
+    phase_scope.record_evaluated_move(std::time::Duration::ZERO);
+    assert!(phase_scope.report_progress_if_due());
+    assert_eq!(publications.load(Ordering::SeqCst), 1);
+
+    phase_scope.record_generated_move(std::time::Duration::ZERO);
+    phase_scope.record_evaluated_move(std::time::Duration::ZERO);
+    assert!(!phase_scope.report_progress_if_due());
+    assert_eq!(publications.load(Ordering::SeqCst), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- publish the first observed phase work promptly, then retain the existing roughly one-second progress cadence
- route generic, runtime-slot, and specialized list construction through one engine-owned lifecycle boundary
- record real generated, evaluated, accepted, applied, timing, and score-calculation telemetry in specialized construction kernels
- poll candidate hot loops only on the first evaluation and every 256 evaluations
- document that Rust applications and host-language bindings consume the same solver events; wrappers do not synthesize construction steps

## Root cause

Construction visibility depended on which kernel executed and how long the host process happened to run. The generic construction phase emitted structured lifecycle events, but specialized list constructors created `PhaseScope` directly. Several specialized loops also did not update the shared candidate counters or poll progress at all. Finally, the progress pulse waited for its first one-second deadline, so fast construction could legitimately produce only start and end lines.

This also made Python examples look richer than Rust use cases when the extra Python lines were application-level post-solve prints rather than solver telemetry.

## Result

With `verbose-logging`, construction now follows the same console contract as local search:

1. phase start
2. prompt progress after real work is observed
3. rate-limited progress during long-running work
4. phase end with exact accumulated totals

The default INFO lifecycle output remains unchanged. There is no per-candidate console flood, wrapper-specific reconstruction, compatibility path, or eager candidate collection.

## Validation

- `make pre-release`
  - formatting passed
  - clippy passed with warnings denied
  - all workspace tests passed
  - all 705 `solverforge-solver` tests passed
  - macro pass/fail fixtures passed
- `make build`
- `make examples`
- `make test-doc`
- focused scored and unscored construction progress regressions
- real `list-tsp` run with `solverforge/console,solverforge/verbose-logging`, confirming a construction progress line appears between phase start and phase end in a sub-millisecond phase
